### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/mailpile/plugins/keylookup/nicknym.py
+++ b/mailpile/plugins/keylookup/nicknym.py
@@ -63,7 +63,7 @@ class Nicknym:
         return json.loads(result), ""
 
     def _nickserver_get_key(self, address, keytype="openpgp", server=None):
-        if server == None: server = self._discover_server(address)
+        if server is None: server = self._discover_server(address)
 
         data = urllib.urlencode({"address": address})
         with ConnBroker.context(need=[ConnBroker.OUTGOING_HTTP]):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:Mailpile?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:Mailpile?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
