### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/mailpile/__init__.py
+++ b/mailpile/__init__.py
@@ -49,7 +49,7 @@ class Mailpile(object):
                 return mailpile.commands.Action(self._session, cmd, '',
                                                 data=kwargs)
 
-        fnc.__doc__ = '%s(%s)  # %s' % (cmd, argspec or '', cls.__doc__)
+        fnc.__doc__ = '{0!s}({1!s})  # {2!s}'.format(cmd, argspec or '', cls.__doc__)
         return cmd.replace('/', '_'), fnc
 
     def Interact(self):

--- a/mailpile/app.py
+++ b/mailpile/app.py
@@ -107,7 +107,7 @@ def Interact(session):
                 except UsageError, e:
                     session.error(unicode(e))
                 except UrlRedirectException, e:
-                    session.error('Tried to redirect to: %s' % e.url)
+                    session.error('Tried to redirect to: {0!s}'.format(e.url))
     except EOFError:
         print
     finally:
@@ -190,7 +190,7 @@ def Main(args):
                                    'please log in!'))
         config.prepare_workers(session)
     except AccessError, e:
-        session.ui.error('Access denied: %s\n' % e)
+        session.ui.error('Access denied: {0!s}\n'.format(e))
         sys.exit(1)
 
     try:

--- a/mailpile/auth.py
+++ b/mailpile/auth.py
@@ -55,9 +55,9 @@ def SetLoggedIn(cmd, user=None, redirect=False, session_id=None):
     sid = session_id or cmd.session.ui.html_variables.get('http_session')
     if sid:
         if cmd:
-            cmd.session.ui.debug('Logged in %s as %s' % (sid, user))
+            cmd.session.ui.debug('Logged in {0!s} as {1!s}'.format(sid, user))
         SESSION_CACHE[sid] = UserSession(auth=user, data={
-            't': '%x' % int(time.time()),
+            't': '{0:x}'.format(int(time.time())),
         })
 
     if cmd:
@@ -97,7 +97,7 @@ class Authenticate(Command):
         qs = [(k, v.encode('utf-8')) for k, vl in data.iteritems() for v in vl
               if k not in ['_method', '_path'] + cls.HTTP_POST_VARS.keys()]
         qs = urlencode(qs)
-        url = ''.join([url, '?%s' % qs if qs else ''])
+        url = ''.join([url, '?{0!s}'.format(qs) if qs else ''])
         raise UrlRedirectException(url)
 
     def _result(self, result=None):
@@ -119,7 +119,7 @@ class Authenticate(Command):
                not path[1:].startswith(self.SYNOPSIS[2] or '!')):
             self.RedirectBack(self.session.config.sys.http_path + path, self.data)
         else:
-            raise UrlRedirectException('%s/' % self.session.config.sys.http_path)
+            raise UrlRedirectException('{0!s}/'.format(self.session.config.sys.http_path))
 
     def _do_login(self, user, password, load_index=False, redirect=False):
         session, config = self.session, self.session.config
@@ -148,7 +148,7 @@ class Authenticate(Command):
                         except KeyboardInterrupt:
                             pass
 
-                    session.ui.debug('Good passphrase for %s' % session_id)
+                    session.ui.debug('Good passphrase for {0!s}'.format(session_id))
                     self.record_user_activity()
                     return self._success(_('Hello world, welcome!'), result={
                         'authenticated': SetLoggedIn(self, redirect=redirect)
@@ -159,7 +159,7 @@ class Authenticate(Command):
                     user = 'DEFAULT'
 
             except (AssertionError, IOError):
-                session.ui.debug('Bad passphrase for %s' % session_id)
+                session.ui.debug('Bad passphrase for {0!s}'.format(session_id))
                 return self._error(_('Invalid passphrase, please try again'))
 
         if user in config.logins or user == 'DEFAULT':
@@ -214,7 +214,7 @@ class DeAuthenticate(Command):
 
         if session_id:
             try:
-                self.session.ui.debug('Logging out %s' % session_id)
+                self.session.ui.debug('Logging out {0!s}'.format(session_id))
                 del SESSION_CACHE[session_id]
                 return self._success(_('Goodbye!'))
             except KeyError:

--- a/mailpile/command_cache.py
+++ b/mailpile/command_cache.py
@@ -56,7 +56,7 @@ class CommandCache(object):
             #       for refreshing.
             self.cache[str(fprint)] = [expires, req, ss, cmd_obj, result_obj,
                                        time.time()]
-            self.debug('Cached %s, req=%s' % (fprint, sorted(list(req))))
+            self.debug('Cached {0!s}, req={1!s}'.format(fprint, sorted(list(req))))
 
     def get_result(self, fprint, dirty_check=True, extend=300):
         with self.lock:
@@ -67,12 +67,11 @@ class CommandCache(object):
             if recent or dirty:
                 # If item is too new, or requirements are dirty, pretend this
                 # item does not exist.
-                self.debug('Suppressing cache result %s, recent=%s dirty=%s'
-                           % (fprint, recent, sorted(list(dirty))))
+                self.debug('Suppressing cache result {0!s}, recent={1!s} dirty={2!s}'.format(fprint, recent, sorted(list(dirty))))
                 raise KeyError(fprint)
         match[0] = time.time() + extend
         co.session = result_obj.session = ss
-        self.debug('Returning cached result for %s' % fprint)
+        self.debug('Returning cached result for {0!s}'.format(fprint))
         return result_obj
 
     def dirty_set(self, after=0):
@@ -86,7 +85,7 @@ class CommandCache(object):
     def mark_dirty(self, requirements):
         with self.lock:
             self.dirty.append((time.time(), set(requirements)))
-        self.debug('Marked dirty: %s' % sorted(list(requirements)))
+        self.debug('Marked dirty: {0!s}'.format(sorted(list(requirements))))
 
     def refresh(self, extend=0, runtime=5, event_log=None):
         if mailpile.util.LIVE_USER_ACTIVITIES > 0:
@@ -144,7 +143,7 @@ class CommandCache(object):
                           source=self,
                           data={'cache_ids': refreshed},
                           flags=Event.COMPLETE)
-            self.debug('Refreshed: %s' % refreshed)
+            self.debug('Refreshed: {0!s}'.format(refreshed))
 
 
 class Cached(Command):

--- a/mailpile/commands.py
+++ b/mailpile/commands.py
@@ -119,10 +119,10 @@ class Command(object):
 
         def as_text(self):
             if isinstance(self.result, bool):
-                happy = '%s: %s' % (self.result and _('OK') or _('Failed'),
+                happy = '{0!s}: {1!s}'.format(self.result and _('OK') or _('Failed'),
                                     self.message or self.doc)
                 if not self.result and self.error_info:
-                    return '%s\n%s' % (happy,
+                    return '{0!s}\n{1!s}'.format(happy,
                         json.dumps(self.error_info, indent=4,
                                    default=mailpile.util.json_helper))
                 else:
@@ -153,7 +153,7 @@ class Command(object):
                 'message': self.message,
                 'result': self.result,
                 'event_id': self.command_obj.event.event_id,
-                'elapsed': '%.3f' % self.session.ui.time_elapsed,
+                'elapsed': '{0:.3f}'.format(self.session.ui.time_elapsed),
             }
             csrf_token = self.session.ui.html_variables.get('csrf_token')
             if csrf_token:
@@ -267,7 +267,7 @@ class Command(object):
         from mailpile.urlmap import UrlMap
         args = sorted(list((sqa or self.state_as_query_args()).iteritems()))
         # The replace() stuff makes these usable as CSS class IDs
-        return ('%s-%s' % (UrlMap(self.session).ui_url(self),
+        return ('{0!s}-{1!s}'.format(UrlMap(self.session).ui_url(self),
                            md5_hex(str(args))
                            )).replace('/', '-').replace('.', '-')
 
@@ -298,7 +298,7 @@ class Command(object):
             # Security: The template request may come from the URL, so we
             #           sanitize it very aggressively before heading off
             #           to the filesystem.
-            clean_tpl = CleanText(template.replace('.%s' % ttype, ''),
+            clean_tpl = CleanText(template.replace('.{0!s}'.format(ttype), ''),
                                   banned=(CleanText.FS +
                                           CleanText.WHITESPACE))
             path_parts.append(clean_tpl.clean)
@@ -431,8 +431,8 @@ class Command(object):
         ui_message = _('%s error: %s') % (self.name, message)
         if info:
             self.error_info.update(info)
-            details = ' '.join(['%s=%s' % (k, info[k]) for k in info])
-            ui_message += ' (%s)' % details
+            details = ' '.join(['{0!s}={1!s}'.format(k, info[k]) for k in info])
+            ui_message += ' ({0!s})'.format(details)
         self.session.ui.mark(self.name)
         self.session.ui.error(ui_message)
 
@@ -445,7 +445,7 @@ class Command(object):
         self.status = 'success'
         self.message = message
 
-        ui_message = '%s: %s' % (self.name, message)
+        ui_message = '{0!s}: {1!s}'.format(self.name, message)
         self.session.ui.mark(ui_message)
 
         return self.view(result)
@@ -976,7 +976,7 @@ class SearchResults(dict):
                     cids = self._msg_addresses(
                         addresses=AddressHeaderParser(
                             unicode_data=editing_strings[key]))
-                    editing_strings['%s_aids' % key] = cids
+                    editing_strings['{0!s}_aids'.format(key)] = cids
                     for cid in cids:
                         if cid not in self['data']['addresses']:
                             self['data']['addresses'
@@ -1146,8 +1146,8 @@ class SearchResults(dict):
 
     def as_text(self):
         from mailpile.www.jinjaextensions import MailpileCommand as JE
-        clen = max(3, len('%d' % len(self.session.results)))
-        cfmt = '%%%d.%ds' % (clen, clen)
+        clen = max(3, len('{0:d}'.format(len(self.session.results))))
+        cfmt = '%{0:d}.{1:d}s'.format(clen, clen)
 
         term_width = self.session.ui.term.max_width()
         fs_width = int((22 + 53) * (term_width / 79.0))
@@ -1180,7 +1180,7 @@ class SearchResults(dict):
                     es[0] = 'S'
             es = ''.join([e for e in es if e])
             if es:
-                msg_meta = (msg_meta or '  ') + ('[%s]' % es)
+                msg_meta = (msg_meta or '  ') + ('[{0!s}]'.format(es))
             elif msg_meta:
                 msg_meta += ')'
             else:
@@ -1196,9 +1196,9 @@ class SearchResults(dict):
             if '@' in from_info and len(from_info) > 18:
                 e, d = from_info.split('@', 1)
                 if d in ('gmail.com', 'yahoo.com', 'hotmail.com'):
-                    from_info = '%s@%s..' % (e, d[0])
+                    from_info = '{0!s}@{1!s}..'.format(e, d[0])
                 else:
-                    from_info = '%s..@%s' % (e[0], d)
+                    from_info = '{0!s}..@{1!s}'.format(e[0], d)
 
             if not expand_ids:
                 def gg(pos):
@@ -1209,11 +1209,11 @@ class SearchResults(dict):
                     thread.append(m['mid'])
                 pos = thread.index(m['mid']) + 1
                 if pos > 1:
-                    from_info = '%s>%s' % (gg(pos-1), from_info)
+                    from_info = '{0!s}>{1!s}'.format(gg(pos-1), from_info)
                 else:
                     from_info = '  ' + from_info
                 if pos < len(thread):
-                    from_info = '%s>%s' % (from_info[:20], gg(len(thread)-pos))
+                    from_info = '{0!s}>{1!s}'.format(from_info[:20], gg(len(thread)-pos))
 
             subject = re.sub('^(\\[[^\\]]{6})[^\\]]{3,}\\]\\s*', '\\1..] ',
                              JE._nice_subject(m))
@@ -1236,7 +1236,7 @@ class SearchResults(dict):
                 if msg_tree['attachments']:
                     text.append('\nAttachments:')
                     for a in msg_tree['attachments']:
-                        text.append('%5.5s %s' % ('#%s' % a['count'],
+                        text.append('{0:5.5!s} {1!s}'.format('#{0!s}'.format(a['count']),
                                                   a['filename']))
                 text.append('-' * term_width)
 
@@ -1317,7 +1317,7 @@ class Rescan(Command):
             for msg_idx_pos in msg_idxs:
                 e = Email(idx, msg_idx_pos)
                 try:
-                    session.ui.mark('Re-indexing %s' % e.msg_mid())
+                    session.ui.mark('Re-indexing {0!s}'.format(e.msg_mid()))
                     idx.index_email(self.session, e)
                 except KeyboardInterrupt:
                     raise
@@ -1554,7 +1554,7 @@ class BrowseOrLaunch(Command):
 
     @classmethod
     def Browse(cls, sspec):
-        http_url = ('http://%s:%s%s/' % sspec
+        http_url = ('http://{0!s}:{1!s}{2!s}/'.format(*sspec)
                     ).replace('//0.0.0.0:', '//localhost:')
         try:
             MakePopenUnsafe()
@@ -1614,7 +1614,7 @@ class RunWWW(Command):
                                             daemons=True)
         if config.http_worker:
             sspec = config.http_worker.httpd.sspec
-            http_url = 'http://%s:%s%s/' % sspec
+            http_url = 'http://{0!s}:{1!s}{2!s}/'.format(*sspec)
             if sspec != ospec:
                 (config.sys.http_host, config.sys.http_port,
                  config.sys.http_path) = sspec
@@ -1637,7 +1637,7 @@ class WritePID(Command):
 
     def command(self):
         with vfs.open(self.args[0], 'w') as fd:
-            fd.write('%d' % os.getpid())
+            fd.write('{0:d}'.format(os.getpid()))
         return self._success(_('Wrote PID to %s') % self.args)
 
 
@@ -1652,7 +1652,7 @@ class RenderPage(Command):
 
     def template_path(self, ttype, template_id=None, **kwargs):
         if not template_id:
-            template_id = '%s/%s' % (self.SYNOPSIS[2],
+            template_id = '{0!s}/{1!s}'.format(self.SYNOPSIS[2],
                                      self.args and self.args[0] or '')
         return Command.template_path(self, ttype, template_id=template_id,
                                      **kwargs)
@@ -1678,8 +1678,7 @@ class ProgramStatus(Command):
 
             sessions = self.result.get('sessions')
             if sessions:
-                sessions = '\n'.join(sorted(['  %s/%s = %s (%ds)'
-                                             % (us['sessionid'],
+                sessions = '\n'.join(sorted(['  {0!s}/{1!s} = {2!s} ({3:d}s)'.format(us['sessionid'],
                                                 us['userdata'],
                                                 us['userinfo'],
                                                 now - us['timestamp'])
@@ -1690,14 +1689,14 @@ class ProgramStatus(Command):
             ievents = self.result.get('ievents')
             cevents = self.result.get('cevents')
             if cevents:
-                cevents = '\n'.join(['  %s' % (e.as_text(compact=True),)
+                cevents = '\n'.join(['  {0!s}'.format(e.as_text(compact=True))
                                      for e in cevents])
             else:
                 cevents = '  ' + _('Nothing Found')
 
             ievents = self.result.get('ievents')
             if ievents:
-                ievents = '\n'.join([' %s' % (e.as_text(compact=True),)
+                ievents = '\n'.join([' {0!s}'.format(e.as_text(compact=True))
                                      for e in ievents])
             else:
                 ievents = '  ' + _('Nothing Found')
@@ -1811,7 +1810,7 @@ class GpgCommand(Command):
 
     class CommandResult(Command.CommandResult):
         def as_text(self):
-            return '%s' % self.message
+            return '{0!s}'.format(self.message)
 
     def command(self, args=None):
         args = list((args is None) and self.args or args or [])
@@ -1878,7 +1877,7 @@ class ListDir(Command):
                 info = vfs.getinfo(f, self.session.config)
                 info['icon'] = ''
                 for k in info.get('flags', []):
-                    info['flag_%s' % unicode(k).lower().replace('.', '_')
+                    info['flag_{0!s}'.format(unicode(k).lower().replace('.', '_'))
                          ] = True
             except (OSError, IOError, UnicodeDecodeError):
                 info['flag_error'] = True
@@ -1991,7 +1990,7 @@ class CatFile(Command):
         for fn in files:
             with vfs.open(fn, 'r') as fd:
                 def errors(where):
-                    self.session.ui.error('Decrypt failed at %d' % where)
+                    self.session.ui.error('Decrypt failed at {0:d}'.format(where))
                 decrypt_and_parse_lines(fd, cb, self.session.config,
                                         newlines=True, decode=None,
                                         _raise=False, error_cb=errors)
@@ -2114,7 +2113,7 @@ class ConfigSet(Command):
                         cfg, v1, v2 = config.walk(path.strip(), parent=2)
                         cfg[v1] = {v2: value}
                 except TypeError:
-                    raise ValueError('Could not set variable: %s' % path)
+                    raise ValueError('Could not set variable: {0!s}'.format(path))
 
         if config.loaded_config:
             self._background_save(config=True)
@@ -2267,11 +2266,11 @@ class ConfigPrint(Command):
                                                   recurse, sanitize)
                     else:
                         if 'name' in rv[key]:
-                            rv[key] = '{ ..(%s).. }' % rv[key]['name']
+                            rv[key] = '{{ ..({0!s}).. }}'.format(rv[key]['name'])
                         elif 'description' in rv[key]:
-                            rv[key] = '{ ..(%s).. }' % rv[key]['description']
+                            rv[key] = '{{ ..({0!s}).. }}'.format(rv[key]['description'])
                         elif 'host' in rv[key]:
-                            rv[key] = '{ ..(%s).. }' % rv[key]['host']
+                            rv[key] = '{{ ..({0!s}).. }}'.format(rv[key]['host'])
                         else:
                             rv[key] = '{ ... }'
                 elif sanitize and key.lower()[:4] in ('pass', 'secr'):
@@ -2441,12 +2440,11 @@ class ConfigureMailboxes(Command):
                         has_source = True
                     configure.append((fn, einfo))
                     if not account:
-                        session.ui.warning('Already in the pile: %s'
-                                           % fn_display)
+                        session.ui.warning('Already in the pile: {0!s}'.format(fn_display))
                 elif IsMailbox(fn.raw_fp, config):
                     adding.append(fn)
                 elif recurse and vfs.exists(fn) and vfs.isdir(fn):
-                    session.ui.mark('Scanning %s for mailboxes' % fn_display)
+                    session.ui.mark('Scanning {0!s} for mailboxes'.format(fn_display))
                     try:
                         for f in [f for f in vfs.listdir(fn)
                                   if not f.raw_fp.startswith('.')]:
@@ -2586,15 +2584,15 @@ class Pipe(Command):
 
         elif '@' in target[0]:
             from mailpile.plugins.compose import Compose
-            body = 'Result as %s:\n%s' % (capture.render_mode, output)
+            body = 'Result as {0!s}:\n{1!s}'.format(capture.render_mode, output)
             if capture.render_mode != 'json' and output[0] not in ('{', '['):
-                body += '\n\nResult as JSON:\n%s' % result.as_json()
+                body += '\n\nResult as JSON:\n{0!s}'.format(result.as_json())
             composer = Compose(self.session, data={
                 'to': target,
-                'subject': ['Mailpile: %s %s' % (command, ' '.join(args))],
+                'subject': ['Mailpile: {0!s} {1!s}'.format(command, ' '.join(args))],
                 'body': [body]
             })
-            return self._success('Mailing output to %s' % ', '.join(target),
+            return self._success('Mailing output to {0!s}'.format(', '.join(target)),
                                  result=composer.run())
         else:
             try:
@@ -2607,11 +2605,10 @@ class Pipe(Command):
                 MakePopenSafe()
                 kid.wait()
             if kid.returncode != 0:
-                return self._error('Error piping to %s' % (target, ),
+                return self._error('Error piping to {0!s}'.format(target ),
                                    info={'stderr': rv[1], 'stdout': rv[0]})
 
-        return self._success('Wrote %d bytes to %s'
-                             % (len(output), ' '.join(target)))
+        return self._success('Wrote {0:d} bytes to {1!s}'.format(len(output), ' '.join(target)))
 
 
 class Quit(Command):
@@ -2739,7 +2736,7 @@ class Help(Command):
         def variables_as_text(self):
             text = []
             for group in self.result['variables']:
-                text.append('%s (%s.*)' % (group['name'], group['category']))
+                text.append('{0!s} ({1!s}.*)'.format(group['name'], group['category']))
                 for var in group['variables']:
                     sep = ('=' in var['type']) and ': ' or ' = '
                     text.append(('  %-35s %s'
@@ -2768,19 +2765,19 @@ class Help(Command):
                 if c[0] == '_':
                     c = '  '
                 else:
-                    c = '%s|' % c[0]
-                fmt = '  %%s%%-%d.%ds' % (width, width)
+                    c = '{0!s}|'.format(c[0])
+                fmt = '  %s%-{0:d}.{1:d}s'.format(width, width)
                 if explanation:
                     if len(args or '') <= arg_width:
-                        fmt += ' %%-%d.%ds %%s' % (arg_width, arg_width)
+                        fmt += ' %-{0:d}.{1:d}s %s'.format(arg_width, arg_width)
                     else:
                         pad = len(c) + width + 3 + arg_width
-                        fmt += ' %%s\n%s %%s' % (' ' * pad)
+                        fmt += ' %s\n{0!s} %s'.format((' ' * pad))
                 else:
                     explanation = ''
                     fmt += ' %s %s '
                 text.append(fmt % (c, cmd.replace('=', ''),
-                                   args and ('%s' % (args, )) or '',
+                                   args and ('{0!s}'.format(args )) or '',
                                    (explanation.splitlines() or [''])[0]))
             if self.result.get('tags'):
                 text.extend([
@@ -2820,7 +2817,7 @@ class Help(Command):
                     for scls in sorted(subs):
                         sc, scmd, surl, ssynopsis = scls.SYNOPSIS[:4]
                         order += 1
-                        cmd_list['_%s' % scmd] = (scmd, ssynopsis,
+                        cmd_list['_{0!s}'.format(scmd)] = (scmd, ssynopsis,
                                                   scls.__doc__, order)
                         width = max(len(scmd or surl), width)
                     return self._success(_('Displayed help'), result={
@@ -2840,7 +2837,7 @@ class Help(Command):
                         continue
                     c, name, url, synopsis = cls.SYNOPSIS[:4]
                     if cls.ORDER[0] == grp and '/' not in (name or ''):
-                        cmd_list[c or '_%s' % name] = (name, synopsis,
+                        cmd_list[c or '_{0!s}'.format(name)] = (name, synopsis,
                                                        cls.__doc__,
                                                        count + cls.ORDER[1])
             if config.loaded_config:
@@ -2917,7 +2914,7 @@ class HelpSplash(Help):
 
         in_browser = False
         if http_worker:
-            http_url = 'http://%s:%s%s/' % http_worker.httpd.sspec
+            http_url = 'http://{0!s}:{1!s}{2!s}/'.format(*http_worker.httpd.sspec)
             if ((sys.platform[:3] in ('dar', 'win') or os.getenv('DISPLAY'))
                     and self.session.config.prefs.open_in_browser):
                 if BrowseOrLaunch.Browse(http_worker.httpd.sspec):
@@ -2961,7 +2958,7 @@ def Action(session, opt, arg, data=None):
             if opt.lower() in (tag.name.lower(),
                                tag.slug.lower(),
                                _(tag.name).lower()):
-                a = 'in:%s%s%s' % (tag.slug, ' ' if arg else '', arg)
+                a = 'in:{0!s}{1!s}{2!s}'.format(tag.slug, ' ' if arg else '', arg)
                 return GetCommand('search')(session, opt,
                                             arg=a, data=data).run()
 

--- a/mailpile/config.py
+++ b/mailpile/config.py
@@ -158,7 +158,7 @@ def ConfigPrinter(cfg, indent=''):
         pairer = enumerate(cfg)
     for key, val in pairer:
         if hasattr(val, 'rules'):
-            preamble = '[%s: %s] ' % (val._NAME, val._COMMENT)
+            preamble = '[{0!s}: {1!s}] '.format(val._NAME, val._COMMENT)
         else:
             preamble = ''
         if isinstance(val, (dict, list, tuple)):
@@ -170,9 +170,9 @@ def ConfigPrinter(cfg, indent=''):
                        '' % (key, preamble, b, ConfigPrinter(val, '  '), e)
                        ).replace('\n  \n', ''))
         elif isinstance(val, (str, unicode)):
-            rv.append('%s: "%s"' % (key, val))
+            rv.append('{0!s}: "{1!s}"'.format(key, val))
         else:
-            rv.append('%s: %s' % (key, val))
+            rv.append('{0!s}: {1!s}'.format(key, val))
     return indent + ',\n'.join(rv).replace('\n', '\n'+indent)
 
 
@@ -216,7 +216,7 @@ class CommentedEscapedConfigParser(ConfigParser.RawConfigParser):
             value = value[:-1] + '%20'
         if comment:
             pad = ' ' * (25 - len(key) - len(value)) + ' ; '
-            value = '%s%s%s' % (value, pad, comment)
+            value = '{0!s}{1!s}{2!s}'.format(value, pad, comment)
         return ConfigParser.RawConfigParser.set(self, section, key, value)
 
     def _decode_value(self, value):
@@ -446,9 +446,9 @@ def WebRootCheck(path):
         ...
     ValueError: Invalid web root: /foo/$%!
     """
-    p = re.sub('/+', '/', '/%s/' % path)[:-1]
+    p = re.sub('/+', '/', '/{0!s}/'.format(path))[:-1]
     if (p != CleanText(p, banned=CleanText.NONPATH).clean):
-        raise ValueError('Invalid web root: %s' % path)
+        raise ValueError('Invalid web root: {0!s}'.format(path))
     return p
 
 
@@ -677,7 +677,7 @@ def RuledContainer(pcls):
             config = config or CommentedEscapedConfigParser()
             section = self._name
             if self._comment:
-                section += ': %s' % self._comment
+                section += ': {0!s}'.format(self._comment)
             added_section = False
 
             keys = self.rules.keys()
@@ -727,8 +727,7 @@ def RuledContainer(pcls):
             if not ((isinstance(rule, (list, tuple))) and
                     (key == CleanText(key, banned=CleanText.NONVARS).clean) and
                     (not self.real_hasattr(key))):
-                raise TypeError('add_rule(%s, %s): Bad key or rule.'
-                                % (key, rule))
+                raise TypeError('add_rule({0!s}, {1!s}): Bad key or rule.'.format(key, rule))
 
             orule, rule = rule, ConfigRule(*rule[:])
             if hasattr(orule, '_types'):
@@ -742,7 +741,7 @@ def RuledContainer(pcls):
             except TypeError:
                 pass
 
-            name = '%s/%s' % (self._name, key)
+            name = '{0!s}/{1!s}'.format(self._name, key)
             comment = rule[self.RULE_COMMENT]
             value = rule[self.RULE_DEFAULT]
 
@@ -798,7 +797,7 @@ def RuledContainer(pcls):
                 rule = rule[:]
                 rule[self.RULE_CHECKER] = _MakeCheck(
                     ConfigDict,
-                    '%s/%s' % (self._name, key),
+                    '{0!s}/{1!s}'.format(self._name, key),
                     rule[self.RULE_COMMENT],
                     rule[self.RULE_CHECKER])
             return rule
@@ -872,7 +871,7 @@ def RuledContainer(pcls):
         def __passkey__(self, key, value):
             if hasattr(value, '__passkey__'):
                 value._key = key
-                value._name = '%s/%s' % (self._name, key)
+                value._name = '{0!s}/{1!s}'.format(self._name, key)
 
         def __passkey_recurse__(self, key, value):
             if hasattr(value, '__passkey__'):
@@ -980,7 +979,7 @@ class ConfigList(RuledContainer(list)):
         if hasattr(value, '__passkey__'):
             key = b36(key).lower()
             value._key = key
-            value._name = '%s/%s' % (self._name, key)
+            value._name = '{0!s}/{1!s}'.format(self._name, key)
 
     def __fixkey__(self, key):
         if isinstance(key, (str, unicode)):
@@ -1595,7 +1594,7 @@ class ConfigManager(ConfigDict):
         if (self._master_key_passgen != master_passphrase.generation
                 or self._master_key_ondisk != self.master_key):
             if os.path.exists(keyfile):
-                want_renamed_keyfile = keyfile + ('.%x' % time.time())
+                want_renamed_keyfile = keyfile + ('.{0:x}'.format(time.time()))
 
         if not want_renamed_keyfile and os.path.exists(keyfile):
             # Key file exists, nothing needs to be changed. Happy!
@@ -1634,7 +1633,7 @@ class ConfigManager(ConfigDict):
         return False
 
     def _unlocked_save(self, session=None):
-        newfile = '%s.new' % self.conffile
+        newfile = '{0!s}.new'.format(self.conffile)
         pubfile = self.conf_pub
         keyfile = self.conf_key
 
@@ -1805,7 +1804,7 @@ class ConfigManager(ConfigDict):
                 mbx_id = FormatMbxId(mailbox_id)
                 mfn = self.sys.mailbox[mbx_id]
                 src = self._find_mail_source(mailbox_id, path=mfn)
-                pfn = 'pickled-mailbox.%s' % mbx_id.lower()
+                pfn = 'pickled-mailbox.{0!s}'.format(mbx_id.lower())
                 if prefer_local and src and src.mailbox[mbx_id] is not None:
                     mfn = src and src.mailbox[mbx_id].local or mfn
                 else:
@@ -1854,7 +1853,7 @@ class ConfigManager(ConfigDict):
                      for p in self._mbox_cache[:-MAX_CACHED_MBOXES]]
         for pfn, mbx_id in flush:
             self.save_worker.add_unique_task(
-                session, 'Save mailbox %s (drop=%s)' % (mbx_id, False),
+                session, 'Save mailbox {0!s} (drop={1!s})'.format(mbx_id, False),
                 lambda: self.uncache_mailbox(session, pfn, drop=False))
 
     def flush_mbox_cache(self, session, clear=True, wait=False):
@@ -1866,7 +1865,7 @@ class ConfigManager(ConfigDict):
             flush = [(p[0], p[1]) for p in self._mbox_cache]
         for pfn, mbx_id in flush:
             saver(session,
-                  'Save mailbox %s (drop=%s)' % (mbx_id, clear),
+                  'Save mailbox {0!s} (drop={1!s})'.format(mbx_id, clear),
                   lambda: self.uncache_mailbox(session, pfn,
                                                drop=clear, force_save=True),
                   unique=True)
@@ -1981,9 +1980,9 @@ class ConfigManager(ConfigDict):
         path = os.path.join(self.workdir, 'mail')
         with self._lock:
             if name is None:
-                name = '%5.5x' % random.randint(0, 16**5)
+                name = '{0:5.5x}'.format(random.randint(0, 16**5))
                 while os.path.exists(os.path.join(path, name)):
-                    name = '%5.5x' % random.randint(0, 16**5)
+                    name = '{0:5.5x}'.format(random.randint(0, 16**5))
             if name != '':
                 if not os.path.exists(path):
                     root_mbx = wervd.MailpileMailbox(path)
@@ -2415,7 +2414,7 @@ class ConfigManager(ConfigDict):
             for w in worker_list:
                 if w and w.isAlive():
                     if config.sys.debug and wait:
-                        print 'Waiting for %s' % w
+                        print 'Waiting for {0!s}'.format(w)
                     w.quit(join=wait)
 
         # Flush the mailbox cache (queues save worker jobs)
@@ -2427,7 +2426,7 @@ class ConfigManager(ConfigDict):
             save_worker = config.save_worker
             config.save_worker = config.dumb_worker
         if config.sys.debug:
-            print 'Waiting for %s' % save_worker
+            print 'Waiting for {0!s}'.format(save_worker)
 
         from mailpile.postinglist import PLC_CACHE_FlushAndClean
         PLC_CACHE_FlushAndClean(config.background, keep=0)
@@ -2469,7 +2468,7 @@ if __name__ == "__main__":
         cfg.tags = {}
         assert(cfg.tags.a is None)
         for tn in range(0, 11):
-            cfg.tags.append({'name': 'Test Tag %s' % tn})
+            cfg.tags.append({'name': 'Test Tag {0!s}'.format(tn)})
         assert(cfg.tags.a['name'] == 'Test Tag 10')
 
         # This tests the same thing for lists
@@ -2513,6 +2512,6 @@ if __name__ == "__main__":
     results = doctest.testmod(optionflags=doctest.ELLIPSIS,
                               extraglobs={'cfg': cfg,
                                           'session': session})
-    print '%s' % (results, )
+    print '{0!s}'.format(results )
     if results.failed:
         sys.exit(1)

--- a/mailpile/conn_brokers.py
+++ b/mailpile/conn_brokers.py
@@ -168,7 +168,7 @@ class BrokeredContext(object):
         self._reset()
 
     def __str__(self):
-        hostport = '%s:%s' % (self.address or ('unknown', 'none'))
+        hostport = '{0!s}:{1!s}'.format(*(self.address or ('unknown', 'none')))
         if self.error:
             return _('Failed to connect to %s: %s') % (hostport, self.error)
 
@@ -258,15 +258,15 @@ class BaseConnectionBroker(Capability):
         for n in need or []:
             if n not in self.supports:
                 if self._debug is not None:
-                    self._debug('%s: lacking capabilty %s' % (self, n))
-                return self._raise_or_none(_raise, 'Lacking %s' % n)
+                    self._debug('{0!s}: lacking capabilty {1!s}'.format(self, n))
+                return self._raise_or_none(_raise, 'Lacking {0!s}'.format(n))
         for n in reject or []:
             if n in self.supports:
                 if self._debug is not None:
-                    self._debug('%s: unwanted capabilty %s' % (self, n))
-                return self._raise_or_none(_raise, 'Unwanted %s' % n)
+                    self._debug('{0!s}: unwanted capabilty {1!s}'.format(self, n))
+                return self._raise_or_none(_raise, 'Unwanted {0!s}'.format(n))
         if self._debug is not None:
-            self._debug('%s: checks passed!' % (self, ))
+            self._debug('{0!s}: checks passed!'.format(self ))
         return self
 
     def _describe(self, context, conn):
@@ -543,7 +543,7 @@ class BaseConnectionBrokerProxy(TcpConnectionBroker):
 
     def _wrap_ssl(self, conn):
         if self._debug is not None:
-            self._debug('%s: Wrapping socket with SSL' % (self, ))
+            self._debug('{0!s}: Wrapping socket with SSL'.format(self ))
         # FIXME: We're losing the SNI stuff here, which is super lame.
         return ssl.wrap_socket(conn, None, None, ssl_version=self.SSL_VERSION)
 
@@ -667,7 +667,7 @@ class MasterBroker(BaseConnectionBroker):
             except:
                 et, v, t = sys.exc_info()
         if et is not None:
-            context.error = '%s' % v
+            context.error = '{0!s}'.format(v)
             raise et, v, t
 
         context.error = _('No connection method found')
@@ -701,7 +701,7 @@ class NetworkHistory(Command):
             if self.result:
                 def fmt(result):
                     dt = datetime.datetime.fromtimestamp(result[0])
-                    return '%2.2d:%2.2d %s' % (dt.hour, dt.minute, result[-1])
+                    return '{0:2.2d}:{1:2.2d} {2!s}'.format(dt.hour, dt.minute, result[-1])
                 return '\n'.join(fmt(r) for r in self.result)
             return _('No network events recorded')
 
@@ -765,6 +765,6 @@ else:
     import sys
     results = doctest.testmod(optionflags=doctest.ELLIPSIS,
                               extraglobs={})
-    print '%s' % (results, )
+    print '{0!s}'.format(results )
     if results.failed:
         sys.exit(1)

--- a/mailpile/crypto/gpgi.py
+++ b/mailpile/crypto/gpgi.py
@@ -28,7 +28,7 @@ _ = lambda s: s
 
 DEFAULT_KEYSERVERS = ["hkps://hkps.pool.sks-keyservers.net",
                       "hkp://subset.pool.sks-keyservers.net"]
-DEFAULT_KEYSERVER_OPTIONS = ['ca-cert-file=%s' % __file__]
+DEFAULT_KEYSERVER_OPTIONS = ['ca-cert-file={0!s}'.format(__file__)]
 
 GPG_KEYID_LENGTH = 8
 GNUPG_HOMEDIR = None  # None=use what gpg uses
@@ -343,7 +343,7 @@ class GnuPGRecordParser:
         pass  # FIXME
 
     def parse_unknown(self, line):
-        print "Unknown line with code '%s'" % (line,)
+        print "Unknown line with code '{0!s}'".format(line)
 
     def parse_none(line):
         pass
@@ -389,7 +389,7 @@ class StreamReader(Thread):
         self.start()
 
     def __str__(self):
-        return '%s(%s/%s, lines=%s)' % (Thread.__str__(self),
+        return '{0!s}({1!s}/{2!s}, lines={3!s})'.format(Thread.__str__(self),
                                         self.name, self.state, self.lines)
 
     def readin(self, fd, callback):
@@ -424,7 +424,7 @@ class StreamWriter(Thread):
         self.start()
 
     def __str__(self):
-        return '%s(%s/%s)' % (Thread.__str__(self), self.name, self.state)
+        return '{0!s}({1!s}/{2!s})'.format(Thread.__str__(self), self.name, self.state)
 
     def writeout(self, fd, output):
         if isinstance(output, (str, unicode)):
@@ -444,7 +444,7 @@ class StreamWriter(Thread):
             output.close()
         except:
             if not self.partial_write_ok:
-                print '%s: %s bytes left' % (self, total)
+                print '{0!s}: {1!s} bytes left'.format(self, total)
                 traceback.print_exc()
         finally:
             self.state = 'done'
@@ -522,7 +522,7 @@ class GnuPG:
         if self.session:
             self.session.debug(msg.rstrip())
         else:
-            print '%s' % str(msg).rstrip()
+            print '{0!s}'.format(str(msg).rstrip())
 
     def _debug_none(self, msg):
         pass
@@ -565,7 +565,7 @@ class GnuPG:
             args.insert(1, "--no-use-agent")
 
         if self.homedir:
-            args.insert(1, "--homedir=%s" % self.homedir)
+            args.insert(1, "--homedir={0!s}".format(self.homedir))
 
         gpg_retcode = -1
         proc = None
@@ -579,10 +579,10 @@ class GnuPG:
                 args.insert(2, "--passphrase-fd=0")
 
             if not self.passphrase and send_passphrase:
-                self.debug('Running WITHOUT PASSPHRASE %s' % ' '.join(args))
+                self.debug('Running WITHOUT PASSPHRASE {0!s}'.format(' '.join(args)))
                 self.debug(traceback.format_stack())
             else:
-                self.debug('Running %s' % ' '.join(args))
+                self.debug('Running {0!s}'.format(' '.join(args)))
 
             # Here we go!
             self.event.update_args(args)
@@ -602,24 +602,24 @@ class GnuPG:
 
             wtf = ' '.join(args)
             self.threads = {
-                "stderr": StreamReader('gpgi-stderr(%s)' % wtf,
+                "stderr": StreamReader('gpgi-stderr({0!s})'.format(wtf),
                                        proc.stderr, self.parse_stderr)
             }
 
             if outputfd:
                 self.threads["stdout"] = StreamReader(
-                    'gpgi-stdout-to-fd(%s)' % wtf,
+                    'gpgi-stdout-to-fd({0!s})'.format(wtf),
                     proc.stdout, outputfd.write, lines=False)
             else:
                 self.threads["stdout"] = StreamReader(
-                    'gpgi-stdout-parsed(%s)' % wtf,
+                    'gpgi-stdout-parsed({0!s})'.format(wtf),
                     proc.stdout, self.parse_stdout)
 
             if gpg_input:
                 # If we have output, we just stream it. Technically, this
                 # doesn't really need to be a thread at the moment.
-                self.debug('<<STDOUT<< %s' % gpg_input)
-                StreamWriter('gpgi-output(%s)' % wtf,
+                self.debug('<<STDOUT<< {0!s}'.format(gpg_input))
+                StreamWriter('gpgi-output({0!s})'.format(wtf),
                              proc.stdin, gpg_input,
                              partial_write_ok=partial_read_ok).join()
             else:
@@ -644,7 +644,7 @@ class GnuPG:
             outputfd.close()
 
         if gpg_retcode != 0 and _raise:
-            raise _raise('GnuPG failed, exit code: %s' % gpg_retcode)
+            raise _raise('GnuPG failed, exit code: {0!s}'.format(gpg_retcode))
 
         return gpg_retcode, self.outputbuffers
 
@@ -654,10 +654,10 @@ class GnuPG:
                 if thr.isAlive():
                     thr.join(timeout=15)
                     if thr.isAlive() and tries > 1:
-                        print 'WARNING: Failed to reap thread %s' % thr
+                        print 'WARNING: Failed to reap thread {0!s}'.format(thr)
 
     def parse_status(self, line, *args):
-        self.debug('<<STATUS<< %s' % line)
+        self.debug('<<STATUS<< {0!s}'.format(line))
         line = line.replace("[GNUPG:] ", "")
         if line == "":
             return
@@ -666,14 +666,14 @@ class GnuPG:
 
     def parse_stdout(self, line):
         self.event.update_stdout(line)
-        self.debug('<<STDOUT<< %s' % line)
+        self.debug('<<STDOUT<< {0!s}'.format(line))
         self.outputbuffers["stdout"].append(line)
 
     def parse_stderr(self, line):
         self.event.update_stderr(line)
         if line.startswith("[GNUPG:] "):
             return self.parse_status(line)
-        self.debug('<<STDERR<< %s' % line)
+        self.debug('<<STDERR<< {0!s}'.format(line))
         self.outputbuffers["stderr"].append(line)
 
     def parse_keylist(self, keylist):
@@ -1276,7 +1276,7 @@ class GnuPG:
             is_hex_keyid = all(c in hex_digits for c in term)
 
         if is_hex_keyid:
-            return '0x%s' % term
+            return '0x{0!s}'.format(term)
         else:
             return term
 
@@ -1289,7 +1289,7 @@ class GnuPG:
                     "--command-fd=0",
                     "--status-fd=1"] + (gpg_args or [])
         if self.homedir:
-            gpg_args.insert(1, "--homedir=%s" % self.homedir)
+            gpg_args.insert(1, "--homedir={0!s}".format(self.homedir))
 
         proc = None
         try:
@@ -1444,7 +1444,7 @@ class GnuPGExpectScript(threading.Thread):
                 self.variables['passphrase'] = '!!<SPS'
 
     def __str__(self):
-        return '%s: %s' % (threading.Thread.__str__(self), self.state)
+        return '{0!s}: {1!s}'.format(threading.Thread.__str__(self), self.state)
 
     running = property(lambda self: (self.state in self.RUNNING_STATES))
     failed = property(lambda self: False)
@@ -1490,7 +1490,7 @@ class GnuPGExpectScript(threading.Thread):
                 raise TimedOut()
         except TimedOut:
             timebox[0] = 0
-            print 'Boo! %s not found in %s' % (exp, self.before)
+            print 'Boo! {0!s} not found in {1!s}'.format(exp, self.before)
             raise
 
     def run_script(self, proc, script):

--- a/mailpile/crypto/mime.py
+++ b/mailpile/crypto/mime.py
@@ -164,7 +164,7 @@ def UnwrapMimeCrypto(part, protocols=None, psi=None, pei=None, charsets=None, de
             # which breaks signature verification. So we manually parse
             # out the raw payload here.
             head, raw_payload, junk = part.as_string(
-                ).replace('\r\n', '\n').split('\n--%s\n' % boundary, 2)
+                ).replace('\r\n', '\n').split('\n--{0!s}\n'.format(boundary), 2)
 
             part.signature_info = crypto_cls().verify(
                 Normalize(raw_payload), signature.get_payload())
@@ -483,7 +483,7 @@ class MimeEncryptingWrapper(MimeWrapper):
         MimeWrapper.__init__(self, *args, **kwargs)
 
         self.version = MIMEBase(*self.ENCRYPTION_TYPE.split('/'))
-        self.version.set_payload('Version: %s\n' % self.ENCRYPTION_VERSION)
+        self.version.set_payload('Version: {0!s}\n'.format(self.ENCRYPTION_VERSION))
         for h, v in (("Content-Disposition", "attachment"), ):
             self.version.add_header(h, v)
 

--- a/mailpile/crypto/state.py
+++ b/mailpile/crypto/state.py
@@ -47,7 +47,7 @@ class CryptoInfo(dict):
 
     def _set_status(self, value):
         if value not in self.STATUSES:
-            print 'Bogus status for %s: %s' % (type(self), value)
+            print 'Bogus status for {0!s}: {1!s}'.format(type(self), value)
         assert(value in self.STATUSES)
         self._status = value
         self.mix_bubbles()
@@ -56,7 +56,7 @@ class CryptoInfo(dict):
         assert(item in self.KEYS)
         if item == "status":
             if value not in self.STATUSES:
-                print 'Bogus status for %s: %s' % (type(self), value)
+                print 'Bogus status for {0!s}: {1!s}'.format(type(self), value)
             assert(value in self.STATUSES)
             if self._status is None:  # Capture initial value
                 self._status = value
@@ -106,13 +106,13 @@ class CryptoInfo(dict):
             if (self.bubbly and
                    status != mix.part_status and
                    not mix.part_status.startswith('mixed-')):
-                mix["status"] = "mixed-%s" % mix.part_status
+                mix["status"] = "mixed-{0!s}".format(mix.part_status)
             else:
                 mix["status"] = mix.part_status
             self._overwrite_with(mix)
         elif not status.startswith("mixed-"):
             # ci is LESS interesting
-            self["status"] = 'mixed-%s' % status
+            self["status"] = 'mixed-{0!s}'.format(status)
 
 
 class EncryptionInfo(CryptoInfo):

--- a/mailpile/crypto/tor.py
+++ b/mailpile/crypto/tor.py
@@ -37,7 +37,7 @@ class Tor:
         )
 
     def _print_bootstrap_lines(self, line):
-        print '%s' % line
+        print '{0!s}'.format(line)
         pass
 
     def _create_path(self, name):
@@ -105,12 +105,12 @@ if __name__ == "__main__":
 
     print "BEWARE: This test script will probably leak your actual IP to wtfismyip.com."
     print "        But you shouldn't have run a test script that could fail if you didn't want this to happen."
-    print "Your IP (not torified): %s" % (urllib.urlopen(url).read().strip())
+    print "Your IP (not torified): {0!s}".format((urllib.urlopen(url).read().strip()))
 
     t = Tor()
     t.start_tor()
     t.start_proxying_through_tor()
-    print "Your IP (torified): %s" % (urllib.urlopen(url).read().strip())
+    print "Your IP (torified): {0!s}".format((urllib.urlopen(url).read().strip()))
     t.stop_proxying_through_tor()
 
     print "Creating hidden service..."

--- a/mailpile/defaults.py
+++ b/mailpile/defaults.py
@@ -1,13 +1,13 @@
 APPVER = "1.0.0rc0"
 ABOUT = """\
 Mailpile.py              a tool             Copyright 2013-2016, Mailpile ehf
- v%8.0008s         for searching and               <https://www.mailpile.is/>
+ v{0:8.0008!s}         for searching and               <https://www.mailpile.is/>
                organizing piles of e-mail
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of either the GNU Affero General Public License as published by the
 Free Software Foundation. See the file COPYING.md for details.
-""" % APPVER
+""".format(APPVER)
 #############################################################################
 import os
 import sys
@@ -201,7 +201,7 @@ if __name__ == "__main__":
     import mailpile.defaults
     from mailpile.config import ConfigDict
 
-    print '%s' % (ConfigDict(_name='mailpile',
+    print '{0!s}'.format(ConfigDict(_name='mailpile',
                              _comment='Base configuration',
                              _rules=mailpile.defaults.CONFIG_RULES
-                             ).as_config_bytes(), )
+                             ).as_config_bytes() )

--- a/mailpile/eventlog.py
+++ b/mailpile/eventlog.py
@@ -27,7 +27,7 @@ def NewEventId():
     with EVENT_COUNTER_LOCK:
         EVENT_COUNTER = EVENT_COUNTER+1
         EVENT_COUNTER %= 0x100000
-        return '%8.8x-%5.5x-%x' % (time.time(), EVENT_COUNTER, os.getpid())
+        return '{0:8.8x}-{1:5.5x}-{2:x}'.format(time.time(), EVENT_COUNTER, os.getpid())
 
 
 def _ClassName(obj, ignore_regexps=False):
@@ -41,7 +41,7 @@ def _ClassName(obj, ignore_regexps=False):
         module = str(obj.__class__.__module__)
         if module.startswith('mailpile.'):
             module = module[len('mailpile'):]
-        return '%s.%s' % (module, str(obj.__class__.__name__))
+        return '{0!s}.{1!s}'.format(module, str(obj.__class__.__name__))
 
 
 class Event(object):
@@ -144,7 +144,7 @@ class Event(object):
                                                        compact=True)
         except (AttributeError, NameError):
             if compact:
-                return '%s=%s:%s %s' % (self.event_id,
+                return '{0!s}={1!s}:{2!s} {3!s}'.format(self.event_id,
                                         self.source.split('.')[-1],
                                         self.flags, self.message)
             else:
@@ -235,7 +235,7 @@ class EventLog(object):
 
         # Write any incomplete events to the new file
         for e in self.incomplete():
-            self._log_fd.write('%s\n' % e)
+            self._log_fd.write('{0!s}\n'.format(e))
 
         # We're starting over, incomplete events don't count
         self._logged = 0
@@ -260,7 +260,7 @@ class EventLog(object):
         events.sort(key=lambda ev: ev.ts)
         try:
             for event in events:
-                self._log_fd.write('%s\n' % event)
+                self._log_fd.write('{0!s}\n'.format(event))
                 self._events[event.event_id] = event
         except IOError:
             if recursed:
@@ -322,7 +322,7 @@ class EventLog(object):
                     return False
             else:
                 # Unknown keywords match nothing...
-                print 'Unknown keyword: `%s=%s`' % (okw, rule)
+                print 'Unknown keyword: `{0!s}={1!s}`'.format(okw, rule)
                 return False
         return True
 

--- a/mailpile/i18n.py
+++ b/mailpile/i18n.py
@@ -110,7 +110,7 @@ def ActivateTranslation(session, config, language):
                                 [language], codeset="utf-8")
         except IOError:
             if session and language[:2] != 'en':
-                session.ui.debug('Failed to load language %s' % language)
+                session.ui.debug('Failed to load language {0!s}'.format(language))
 
     if not trans:
         trans = translation("mailpile", config.getLocaleDirectory(),

--- a/mailpile/mail_generator.py
+++ b/mailpile/mail_generator.py
@@ -203,7 +203,7 @@ class Generator:
 
     def _write_headers(self, msg):
         for h, v in msg.items():
-            print >> self._fp, '%s:' % h,
+            print >> self._fp, '{0!s}:'.format(h),
             if self._maxheaderlen == 0:
                 # Explicit no-wrapping
                 print >> self._fp, v + self._NL,
@@ -240,7 +240,7 @@ class Generator:
         if payload is None:
             return
         if not isinstance(payload, basestring):
-            raise TypeError('string payload expected: %s' % type(payload))
+            raise TypeError('string payload expected: {0!s}'.format(type(payload)))
         if self._mangle_from_:
             payload = fcre.sub('>From ', payload)
         self._fp.write(payload)
@@ -422,7 +422,7 @@ class DecodedGenerator(Generator):
 
 # Helper
 _width = len(repr(sys.maxint-1))
-_fmt = '%%0%dd' % _width
+_fmt = '%0{0:d}d'.format(_width)
 
 
 def _make_boundary(text=None):

--- a/mailpile/mail_source/__init__.py
+++ b/mailpile/mail_source/__init__.py
@@ -44,7 +44,7 @@ class BaseMailSource(threading.Thread):
             MailpileVfsBase.__init__(self, *args, **kwargs)
             self.config = config
             self.source = source
-            self.root = FilePath('/src:%s' % self.source.my_config._key)
+            self.root = FilePath('/src:{0!s}'.format(self.source.my_config._key))
 
         def _get_mbox_id(self, path):
             return path[len(self.root.raw_fp)+1:]
@@ -72,7 +72,7 @@ class BaseMailSource(threading.Thread):
                 mbox_id = self._get_mbox_id(path)
                 return self.config.sys.mailbox[mbox_id]
             except (ValueError, KeyError, IndexError):
-                raise OSError('Not found: %s' % path)
+                raise OSError('Not found: {0!s}'.format(path))
 
         def isdir_(self, fp):
             return (self.root == fp)
@@ -94,7 +94,7 @@ class BaseMailSource(threading.Thread):
                 mbox_id = self._get_mbox_id(path)
                 return self.source.my_config.mailbox[mbox_id].name
             except (ValueError, KeyError, IndexError):
-                raise OSError('Not found: %s' % path)
+                raise OSError('Not found: {0!s}'.format(path))
 
         def exists_(self, fp):
             return ((self.root == fp) or
@@ -127,11 +127,11 @@ class BaseMailSource(threading.Thread):
     def __str__(self):
         rv = ': '.join([threading.Thread.__str__(self), self._state])
         if self._sleeping > 0:
-            rv += '(%s)' % self._sleeping
+            rv += '({0!s})'.format(self._sleeping)
         return rv
 
     def _pfn(self):
-        return 'mail-source.%s' % self.my_config._key
+        return 'mail-source.{0!s}'.format(self.my_config._key)
 
     def _load_state(self):
         with self._lock:
@@ -167,25 +167,23 @@ class BaseMailSource(threading.Thread):
         self.session.config.event_log.log_event(self.event)
         self.session.ui.mark(message)
         if 'sources' in self.session.config.sys.debug:
-            self.session.ui.debug('%s: %s' % (self, message))
+            self.session.ui.debug('{0!s}: {1!s}'.format(self, message))
 
     def open(self):
         """Open mailboxes or connect to the remote mail source."""
-        raise NotImplemented('Please override open in %s' % self)
+        raise NotImplemented('Please override open in {0!s}'.format(self))
 
     def close(self):
         """Close mailboxes or disconnect from the remote mail source."""
-        raise NotImplemented('Please override open in %s' % self)
+        raise NotImplemented('Please override open in {0!s}'.format(self))
 
     def _has_mailbox_changed(self, mbx, state):
         """For the default sync_mail routine, report if mailbox changed."""
-        raise NotImplemented('Please override _has_mailbox_changed in %s'
-                             % self)
+        raise NotImplemented('Please override _has_mailbox_changed in {0!s}'.format(self))
 
     def _mark_mailbox_rescanned(self, mbx, state):
         """For the default sync_mail routine, note mailbox was rescanned."""
-        raise NotImplemented('Please override _mark_mailbox_rescanned in %s'
-                             % self)
+        raise NotImplemented('Please override _mark_mailbox_rescanned in {0!s}'.format(self))
 
     def _path(self, mbx):
         if mbx.path.startswith('@'):
@@ -478,7 +476,7 @@ class BaseMailSource(threading.Thread):
         with self._lock:
             mailbox_idx = FormatMbxId(mailbox_idx)
             self.my_config.mailbox[mailbox_idx] = {
-                'path': '@%s' % mailbox_idx,
+                'path': '@{0!s}'.format(mailbox_idx),
                 'policy': policy or 'inherit',
                 'process_new': disco_cfg.process_new,
                 'local': '!CREATE' if create_local else '',
@@ -609,7 +607,7 @@ class BaseMailSource(threading.Thread):
                     visible=(disco_cfg.visible_tags if (visible is None)
                              else visible),
                     label=as_label,
-                    slug='mailbox-%s' % mbx_cfg._key,
+                    slug='mailbox-{0!s}'.format(mbx_cfg._key),
                     unique=False,
                     parent=parent)
             except (ValueError, IndexError):
@@ -638,7 +636,7 @@ class BaseMailSource(threading.Thread):
             return tagname
         tagnameN, count = tagname, 2
         while self.session.config.get_tags(tagnameN):
-            tagnameN = '%s (%s)' % (tagname, count)
+            tagnameN = '{0!s} ({1!s})'.format(tagname, count)
             count += 1
         return tagnameN
 
@@ -802,7 +800,7 @@ class BaseMailSource(threading.Thread):
                                 if self._policy(m) not in ('ignore',
                                                            'unknown')]))
         try:
-            ostate, self._state = self._state, 'Rescan(%s, %s)' % (mbx_key,
+            ostate, self._state = self._state, 'Rescan({0!s}, {1!s})'.format(mbx_key,
                                                                    stop_after)
 
             with self._lock:
@@ -1002,7 +1000,7 @@ def ProcessNew(session, msg, msg_metadata_kws, msg_ts, keywords, snippet):
             or 'r' in msg.get('status', '').lower()      # Read, mbox
             or 'a' in msg.get('sx-tatus', '').lower()):  # PINE, answered
         return False
-    keywords.update(['%s:in' % tag._key for tag in
+    keywords.update(['{0!s}:in'.format(tag._key) for tag in
                      session.config.get_tags(type='unread')])
     return True
 

--- a/mailpile/mail_source/imap_utf7.py
+++ b/mailpile/mail_source/imap_utf7.py
@@ -13,7 +13,7 @@ def modified_base64 (s):
 
 def doB64(_in, r):
   if _in:
-    r.append('&%s-' % modified_base64(''.join(_in)))
+    r.append('&{0!s}-'.format(modified_base64(''.join(_in))))
     del _in[:]
 
 def encoder(s):

--- a/mailpile/mail_source/local.py
+++ b/mailpile/mail_source/local.py
@@ -55,7 +55,7 @@ class LocalMailSource(BaseMailSource):
             sz = long(os.path.getsize(mbx_path))
         except (OSError, IOError):
             mt = sz = (int(time.time()) // 7200)  # Guarantee rescans
-        mtsz = state['mtsz'] = '%s/%s' % (mt, sz)
+        mtsz = state['mtsz'] = '{0!s}/{1!s}'.format(mt, sz)
 
         # Check more carefully if it's a Maildir, Mac Maildir or WERVD.
         if os.path.isdir(mbx_path):
@@ -69,7 +69,7 @@ class LocalMailSource(BaseMailSource):
                 try:
                     mt = long(os.path.getmtime(sub_path))
                     sz = long(os.path.getsize(sub_path))
-                    sub_mtsz = '%s/%s' % (mt, sz)
+                    sub_mtsz = '{0!s}/{1!s}'.format(mt, sz)
                     mtsz += ',' + sub_mtsz
                     state['mtsz'] += ',' + sub_mtsz
                 except (OSError, IOError):

--- a/mailpile/mail_source/pop3.py
+++ b/mailpile/mail_source/pop3.py
@@ -75,7 +75,7 @@ class Pop3MailSource(BaseMailSource):
         pop3 = self.session.config.open_mailbox(self.session,
                                                 FormatMbxId(mbx._key),
                                                 prefer_local=False)
-        state['stat'] = stat = '%s' % (pop3.stat(), )
+        state['stat'] = stat = '{0!s}'.format(pop3.stat() )
         return (self.event.data.get('mailbox_state', {}).get(mbx._key) != stat)
 
     def _mark_mailbox_rescanned(self, mbx, state):
@@ -85,7 +85,7 @@ class Pop3MailSource(BaseMailSource):
             self.event.data['mailbox_state'] = {mbx._key: state['stat']}
 
     def _fmt_path(self):
-        return 'src:%s' % (self.my_config._key,)
+        return 'src:{0!s}'.format(self.my_config._key)
 
     def open_mailbox(self, mbx_id, mfn):
         my_cfg = self.my_config

--- a/mailpile/mailboxes/__init__.py
+++ b/mailpile/mailboxes/__init__.py
@@ -53,7 +53,7 @@ def OpenMailbox(fn, config, create=False):
             raise
         except:
             pass
-    raise ValueError('Not a mailbox: %s' % fn)
+    raise ValueError('Not a mailbox: {0!s}'.format(fn))
 
 
 def UnorderedPicklable(parent, editable=False):
@@ -129,7 +129,7 @@ def UnorderedPicklable(parent, editable=False):
             self._refresh()
 
         def get_msg_ptr(self, mboxid, toc_id):
-            return '%s%s' % (mboxid, quote(toc_id))
+            return '{0!s}{1!s}'.format(mboxid, quote(toc_id))
 
         def get_file(self, *args, **kwargs):
             with self._lock:

--- a/mailpile/mailboxes/gmvault.py
+++ b/mailpile/mailboxes/gmvault.py
@@ -19,7 +19,7 @@ class MailpileMailbox(maildir.MailpileMailbox):
                os.path.isdirs(os.path.join(fn, 'chats')) and
                os.path.isdirs(os.path.join(fn, '.info'))):
             return (fn, )
-        raise ValueError('Not a Gmvault: %s' % fn)
+        raise ValueError('Not a Gmvault: {0!s}'.format(fn))
 
     def __init__(self, dirname, factory=rfc822.Message, create=True):
         maildir.MailpileMailbox.__init__(self, dirname, factory, create)

--- a/mailpile/mailboxes/imap.py
+++ b/mailpile/mailboxes/imap.py
@@ -123,7 +123,7 @@ class MailpileMailbox(UnorderedPicklable(IMAPMailbox)):
             user, password = userpart.split(":")
             # WARNING: Order must match IMAPMailbox.__init__(...)
             return (server, 993, user, password)
-        raise ValueError('Not an IMAP url: %s' % path)
+        raise ValueError('Not an IMAP url: {0!s}'.format(path))
 
     def get_msg_size(self, toc_id):
         # FIXME: We should make this less horrible.

--- a/mailpile/mailboxes/macmail.py
+++ b/mailpile/mailboxes/macmail.py
@@ -57,7 +57,7 @@ class MacMaildir(mailbox.Mailbox):
             raise mailbox.FormatError(self._path)
 
         # And finally, there's a Data folder (with .emlx files  in it)
-        self._mailroot = "%s/%s/Data/" % (self._path, self._id)
+        self._mailroot = "{0!s}/{1!s}/Data/".format(self._path, self._id)
         if not os.path.isdir(self._mailroot):
             raise mailbox.FormatError(self._path)
 
@@ -128,7 +128,7 @@ class MacMaildir(mailbox.Mailbox):
         try:
             return self._toc[key]
         except KeyError:
-            raise KeyError("No message with key %s" % key)
+            raise KeyError("No message with key {0!s}".format(key))
 
     def get_message(self, key):
         f = open(os.path.join(self._mailroot, self._lookup(key)), 'r')
@@ -148,7 +148,7 @@ class MailpileMailbox(UnorderedPicklable(MacMaildir)):
         if (os.path.isdir(fn)
                 and os.path.exists(os.path.join(fn, 'Info.plist'))):
             return (fn, )
-        raise ValueError('Not a Mac Mail.app Maildir: %s' % fn)
+        raise ValueError('Not a Mac Mail.app Maildir: {0!s}'.format(fn))
 
 
 mailpile.mailboxes.register(50, MailpileMailbox)

--- a/mailpile/mailboxes/maildir.py
+++ b/mailpile/mailboxes/maildir.py
@@ -20,7 +20,7 @@ class MailpileMailbox(UnorderedPicklable(mailbox.Maildir, editable=True)):
                   os.path.exists(os.path.join(fn, 'cur'))) or
                  (create and not os.path.exists(fn)))):
             return (fn, )
-        raise ValueError('Not a Maildir: %s' % fn)
+        raise ValueError('Not a Maildir: {0!s}'.format(fn))
 
     def _refresh(self):
         with self._lock:
@@ -34,7 +34,7 @@ class MailpileMailbox(UnorderedPicklable(mailbox.Maildir, editable=True)):
         if self.colon in name:
             flags = name.split(self.colon)[-1]
             if flags[:2] == '2,':
-                return ['%s:maildir' % c for c in flags[2:]]
+                return ['{0!s}:maildir'.format(c) for c in flags[2:]]
         return []
 
 

--- a/mailpile/mailboxes/mbox.py
+++ b/mailpile/mailboxes/mbox.py
@@ -23,7 +23,7 @@ class MailpileMailbox(mailbox.mbox):
             if create and not os.path.exists(fn):
                 return (fn, )
             pass
-        raise ValueError('Not an mbox: %s' % fn)
+        raise ValueError('Not an mbox: {0!s}'.format(fn))
 
     def __init__(self, *args, **kwargs):
         mailbox.mbox.__init__(self, *args, **kwargs)
@@ -159,7 +159,7 @@ class MailpileMailbox(mailbox.mbox):
         with self._lock:
             msg_start = self._toc[toc_id][0]
             msg_size = self.get_msg_size(toc_id)
-        return '%s%s:%s:%s' % (mboxid,
+        return '{0!s}{1!s}:{2!s}:{3!s}'.format(mboxid,
                                b36(msg_start),
                                b36(msg_size),
                                self.get_msg_cs80b(msg_start, msg_size))

--- a/mailpile/mailboxes/pop3.py
+++ b/mailpile/mailboxes/pop3.py
@@ -82,7 +82,7 @@ class POP3Mailbox(Mailbox):
     def _get(self, key, _bytes=None):
         with self._lock:
             if key not in self.iterkeys():
-                raise KeyError('Invalid key: %s' % key)
+                raise KeyError('Invalid key: {0!s}'.format(key))
 
             self._connect()
             if _bytes is not None:
@@ -91,7 +91,7 @@ class POP3Mailbox(Mailbox):
             else:
                 ok, lines, octets = self._pop3.retr(self._km[key])
             if not ok.startswith('+OK'):
-                raise KeyError('Invalid key: %s' % key)
+                raise KeyError('Invalid key: {0!s}'.format(key))
 
         # poplib is stupid in that it loses the linefeeds, so we need to
         # do some guesswork to bring them back to what the server provided.
@@ -110,7 +110,7 @@ class POP3Mailbox(Mailbox):
         elif octets == have_octets + 2*len(lines) - 2:
             data = '\r\n'.join(lines)
         else:
-            raise ValueError('Length mismatch in message %s' % key)
+            raise ValueError('Length mismatch in message {0!s}'.format(key))
 
         if _bytes is not None:
             return data[:_bytes]
@@ -133,7 +133,7 @@ class POP3Mailbox(Mailbox):
         with self._lock:
             self._connect()
             if key not in self.iterkeys():
-                raise KeyError('Invalid key: %s' % key)
+                raise KeyError('Invalid key: {0!s}'.format(key))
             ok, info, octets = self._pop3.list(self._km[key]).split()
             return int(octets)
 
@@ -209,7 +209,7 @@ class MailpileMailbox(UnorderedPicklable(POP3Mailbox)):
 
             # WARNING: Order must match POP3Mailbox.__init__(...)
             return (server, user, password, 's' in proto, int(port), debug)
-        raise ValueError('Not a POP3 url: %s' % path)
+        raise ValueError('Not a POP3 url: {0!s}'.format(path))
 
     def save(self, *args, **kwargs):
         # Do not save state locally
@@ -269,8 +269,8 @@ if __name__ == "__main__":
             'stat': (2, 123456),
             'noop': '+OK',
             'list_': lambda s: ('+OK 2 messages:',
-                                ['1 %d' % len(s.TEST_MSG.replace('\r', '')),
-                                 '2 %d' % len(s.TEST_MSG)], 0),
+                                ['1 {0:d}'.format(len(s.TEST_MSG.replace('\r', ''))),
+                                 '2 {0:d}'.format(len(s.TEST_MSG))], 0),
             'uidl': ('+OK', ['1 evil', '2 good'], 0),
             'retr': lambda s, m: ('+OK',
                                   s.TEST_MSG.replace('N', m).splitlines(),
@@ -325,13 +325,13 @@ if __name__ == "__main__":
 
     results = doctest.testmod(optionflags=doctest.ELLIPSIS,
                               extraglobs={})
-    print '%s' % (results, )
+    print '{0!s}'.format(results )
     if results.failed:
         sys.exit(1)
 
     if len(sys.argv) > 1:
         mbx = MailpileMailbox(*MailpileMailbox.parse_path(None, sys.argv[1]))
-        print 'Status is: %s' % (mbx.stat(), )
+        print 'Status is: {0!s}'.format(mbx.stat() )
         print 'Downloading mail and listing subjects, hit CTRL-C to quit'
         for msg in mbx:
             print msg['subject']

--- a/mailpile/mailboxes/wervd.py
+++ b/mailpile/mailboxes/wervd.py
@@ -26,7 +26,7 @@ class MailpileMailbox(UnorderedPicklable(mailbox.Maildir, editable=True)):
                   os.path.exists(os.path.join(fn, 'wervd.ver'))) or
                  (create and not os.path.exists(fn)))):
             return (fn, )
-        raise ValueError('Not a Mailpile Maildir: %s' % fn)
+        raise ValueError('Not a Mailpile Maildir: {0!s}'.format(fn))
 
     def __init2__(self, *args, **kwargs):
         open(os.path.join(self._path, 'wervd.ver'), 'w+b').write('0')
@@ -77,7 +77,7 @@ class MailpileMailbox(UnorderedPicklable(mailbox.Maildir, editable=True)):
         if self.colon in name:
             flags = name.split(self.colon)[-1]
             if flags[:2] == '2,':
-                return ['%s:maildir' % c for c in flags[2:]]
+                return ['{0!s}:maildir'.format(c) for c in flags[2:]]
         return []
 
     def set_metadata_keywords(self, toc_id, kws):
@@ -87,7 +87,7 @@ class MailpileMailbox(UnorderedPicklable(mailbox.Maildir, editable=True)):
 
             flags = ''.join(sorted([k[0] for k in kws]))
             if flags:
-                new_fpath += '%s2,%s' % (self.colon, flags)
+                new_fpath += '{0!s}2,{1!s}'.format(self.colon, flags)
                 if new_fpath != old_fpath:
                     os.rename(os.path.join(self._path, old_fpath),
                               os.path.join(self._path, new_fpath))
@@ -124,7 +124,7 @@ class MailpileMailbox(UnorderedPicklable(mailbox.Maildir, editable=True)):
                                                    'for the message.'))
 
             for cpn in range(1, copies):
-                fn = os.path.join(self._path, 'new', '%s.%s' % (key, cpn))
+                fn = os.path.join(self._path, 'new', '{0!s}.{1!s}'.format(key, cpn))
                 with mailbox._create_carefully(fn) as ofd:
                     es.save_copy(ofd)
 

--- a/mailpile/plugins/__init__.py
+++ b/mailpile/plugins/__init__.py
@@ -114,7 +114,7 @@ class PluginManager(object):
             for subdir in self._listdir(pdir):
                 pname = subdir.lower()
                 if pname in self.BUILTIN:
-                    print 'Cannot overwrite built-in plugin: %s' % pname
+                    print 'Cannot overwrite built-in plugin: {0!s}'.format(pname)
                     continue
                 if pname in self.DISCOVERED and not update:
                     # FIXME: this is lame
@@ -129,7 +129,7 @@ class PluginManager(object):
                         # FIXME: Need more sanity checks
                         self.DISCOVERED[pname] = (plug_path, manifest)
                 except (ValueError, AssertionError):
-                    print 'Bad manifest: %s' % manifest_filename
+                    print 'Bad manifest: {0!s}'.format(manifest_filename)
                 except (OSError, IOError):
                     pass
 
@@ -146,7 +146,7 @@ class PluginManager(object):
         parents = full_name.split('.')[2:] # skip mailpile.plugins
         module = "mailpile.plugins"
         for parent in parents:
-            mp = '%s.%s' % (module, parent)
+            mp = '{0!s}.{1!s}'.format(module, parent)
             if mp not in sys.modules:
                 sys.modules[mp] = imp.new_module(mp)
                 sys.modules[module].__dict__[parent] = sys.modules[mp]
@@ -160,7 +160,7 @@ class PluginManager(object):
                 exec mfd.read() in sys.modules[full_name].__dict__
 
     def _load(self, plugin_name, process_manifest=False, config=None):
-        full_name = 'mailpile.plugins.%s' % plugin_name
+        full_name = 'mailpile.plugins.{0!s}'.format(plugin_name)
         if full_name in sys.modules:
             return
 
@@ -198,7 +198,7 @@ class PluginManager(object):
                 raise
             except:
                 traceback.print_exc(file=sys.stderr)
-                print 'FIXME: Loading %s failed, tell user!' % full_name
+                print 'FIXME: Loading {0!s} failed, tell user!'.format(full_name)
                 return
 
             spec = (full_name, manifest, dirname)
@@ -208,7 +208,7 @@ class PluginManager(object):
                 self._process_manifest_pass_two(*spec)
                 self._process_startup_hooks(*spec)
         else:
-            print 'What what what?? %s' % plugin_name
+            print 'What what what?? {0!s}'.format(plugin_name)
             return self
 
         if plugin_name not in self.LOADED:
@@ -225,7 +225,7 @@ class PluginManager(object):
     def process_shutdown_hooks(self):
         for plugin_name in self.DISCOVERED.keys():
             try:
-                package = 'mailpile.plugins.%s' % plugin_name
+                package = 'mailpile.plugins.{0!s}'.format(plugin_name)
                 _, manifest = self.DISCOVERED[plugin_name]
 
                 if sys.modules.has_key(package):
@@ -247,7 +247,7 @@ class PluginManager(object):
                     if spec[0] not in failed:
                         process(*spec)
                 except Exception, e:
-                    print 'Failed to process manifest for %s: %s' % (spec[0], e)
+                    print 'Failed to process manifest for {0!s}: {1!s}'.format(spec[0], e)
                     failed.append(spec[0])
                     traceback.print_exc()
         return self
@@ -298,7 +298,7 @@ class PluginManager(object):
             # FIXME: This is all a bit hacky, we probably just want to
             #        kill the SYNOPSIS attribute entirely.
             if 'input' in command:
-                name = url = '%s/%s' % (command['input'], command['name'])
+                name = url = '{0!s}/{1!s}'.format(command['input'], command['name'])
                 cls.UI_CONTEXT = command['input']
             else:
                 name = command.get('name', cls.SYNOPSIS[1])
@@ -363,7 +363,7 @@ class PluginManager(object):
                 # the right place for that particular command.
                 commands = []
                 if (not url.startswith('/api/')) and 'api' in info:
-                    url = '/api/%d%s' % (info['api'], url)
+                    url = '/api/{0:d}{1!s}'.format(info['api'], url)
                     if url[-1] == '/':
                         url += 'as.html'
                 for method in ('GET', 'POST', 'PUT', 'UPDATE', 'DELETE'):
@@ -384,7 +384,7 @@ class PluginManager(object):
                                             'html/' + tpath,
                                             filename)
                 else:
-                    print 'FIXME: Un-routable URL in manifest %s' % url
+                    print 'FIXME: Un-routable URL in manifest {0!s}'.format(url)
 
         # Register email content/crypto hooks
         s = self
@@ -395,7 +395,7 @@ class PluginManager(object):
             ('incoming_content', s.register_incoming_email_content_transform)
         ):
             for item in manifest_path('email_transforms', which):
-                name = '%3.3d_%s' % (int(item.get('priority', 999)), full_name)
+                name = '{0:3.3d}_{1!s}'.format(int(item.get('priority', 999)), full_name)
                 reg(name, self._get_class(full_name, item['class']))
 
         # Register search keyword extractors
@@ -406,7 +406,7 @@ class PluginManager(object):
             ('data', s.register_data_kw_extractor)
         ):
             for item in manifest_path('keyword_extractors', which):
-                reg('%s.%s' % (full_name, item),
+                reg('{0!s}.{1!s}'.format(full_name, item),
                     self._get_class(full_name, item))
 
         # Register contact/vcard hooks
@@ -422,7 +422,7 @@ class PluginManager(object):
         def reg_job(info, spd, register):
             interval, cls = info['interval'], info['class']
             callback = self._get_class(full_name, cls)
-            register('%s.%s/%s-%s' % (full_name, cls, spd, interval),
+            register('{0!s}.{1!s}/{2!s}-{3!s}'.format(full_name, cls, spd, interval),
                      interval, callback)
         for info in manifest_path('periodic_jobs', 'fast'):
             reg_job(info, 'fast', self.register_fast_periodic_job)
@@ -435,12 +435,11 @@ class PluginManager(object):
                 if 'javascript_setup' in hook:
                     js = hook['javascript_setup']
                     if not js.startswith('Mailpile.'):
-                       hook['javascript_setup'] = '%s.%s' % (ucfull_name, js)
+                       hook['javascript_setup'] = '{0!s}.{1!s}'.format(ucfull_name, js)
                 if 'javascript_events' in hook:
                     for event, call in hook['javascript_events'].iteritems():
                         if not call.startswith('Mailpile.'):
-                            hook['javascript_events'][event] = '%s.%s' \
-                                % (ucfull_name, call)
+                            hook['javascript_events'][event] = '{0!s}.{1!s}'.format(ucfull_name, call)
                 self.register_ui_element(ui_type, **hook)
 
     def _process_startup_hooks(self, package,
@@ -462,7 +461,7 @@ class PluginManager(object):
                 raise PluginError('Naughty plugin tried to directly access '
                                   'mailpile.plugins!')
 
-            where = '->'.join(['%s:%s' % ('/'.join(stack[i][1].split('/')[-2:]),
+            where = '->'.join(['{0!s}:{1!s}'.format('/'.join(stack[i][1].split('/')[-2:]),
                                           stack[i][2])
                               for i in reversed(range(2, len(stack)-1))])
             print ('FIXME: Deprecated use of %s at %s (issue #547)'
@@ -470,7 +469,7 @@ class PluginManager(object):
 
     def _rhtf(self, kw_hash, term, function):
         if term in kw_hash:
-            raise PluginError('Already registered: %s' % term)
+            raise PluginError('Already registered: {0!s}'.format(term))
         kw_hash[term] = function
 
 
@@ -486,7 +485,7 @@ class PluginManager(object):
             dest = dest[arg][-1]
         for rname, rule in rules.iteritems():
             if rname in dest:
-                raise PluginError('Variable already exist: %s/%s' % (path, rname))
+                raise PluginError('Variable already exist: {0!s}/{1!s}'.format(path, rname))
             else:
                 dest[rname] = rule
 
@@ -500,7 +499,7 @@ class PluginManager(object):
         for arg in args:
             dest = dest[arg][-1]
         if rname in dest:
-            raise PluginError('Section already exist: %s/%s' % (path, rname))
+            raise PluginError('Section already exist: {0!s}/{1!s}'.format(path, rname))
         else:
             dest[rname] = rules
 
@@ -601,7 +600,7 @@ class PluginManager(object):
     def register_search_term(self, term, function):
         self._compat_check()
         if term in self.SEARCH_TERMS:
-            raise PluginError('Already registered: %s' % term)
+            raise PluginError('Already registered: {0!s}'.format(term))
         self.SEARCH_TERMS[term] = function
 
 
@@ -639,10 +638,9 @@ class PluginManager(object):
                 raise PluginError("Please set SHORT_NAME "
                                   "and FORMAT_* attributes!")
             if not issubclass(plugin_class, cls):
-                raise PluginError("%s must be a %s" % (what, cls))
+                raise PluginError("{0!s} must be a {1!s}".format(what, cls))
             if plugin_class.SHORT_NAME in dct:
-                raise PluginError("%s for %s already registered"
-                                  % (what, importer.FORMAT_NAME))
+                raise PluginError("{0!s} for {1!s} already registered".format(what, importer.FORMAT_NAME))
 
             if plugin_class.CONFIG_RULES:
                 rules = {
@@ -720,10 +718,10 @@ class PluginManager(object):
     WEB_ASSETS = {}
 
     def register_js(self, plugin, classname, filename):
-        self.JS_CLASSES['%s.%s' % (plugin, classname)] = filename
+        self.JS_CLASSES['{0!s}.{1!s}'.format(plugin, classname)] = filename
 
     def register_css(self, plugin, classname, filename):
-        self.CSS_FILES['%s.%s' % (plugin, classname)] = filename
+        self.CSS_FILES['{0!s}.{1!s}'.format(plugin, classname)] = filename
 
     def register_web_asset(self, plugin, path, filename, mimetype='text/html'):
         if path in self.WEB_ASSETS:
@@ -772,7 +770,7 @@ class PluginManager(object):
                 info[k] = v
             self.UI_ELEMENTS[ui_type].append(info)
         else:
-            raise ValueError('Duplicate element: %s' % name)
+            raise ValueError('Duplicate element: {0!s}'.format(name))
 
     def get_ui_elements(self, ui_type, context):
         # FIXME: This is a bit inefficient.

--- a/mailpile/plugins/autotag.py
+++ b/mailpile/plugins/autotag.py
@@ -68,7 +68,7 @@ def SaveAutoTagger(config, at_config):
     aid = at_identify(at_config)
     at = config.autotag.get(aid)
     if at and at.trained:
-        config.save_pickle(at, 'pickled-autotag.%s' % aid)
+        config.save_pickle(at, 'pickled-autotag.{0!s}'.format(aid))
 
 
 def LoadAutoTagger(config, at_config):
@@ -77,7 +77,7 @@ def LoadAutoTagger(config, at_config):
     aid = at_identify(at_config)
     at = config.autotag.get(aid)
     if aid not in config.autotag:
-        cfn = 'pickled-autotag.%s' % aid
+        cfn = 'pickled-autotag.{0!s}'.format(aid)
         try:
             config.autotag[aid] = config.load_pickle(cfn)
         except (IOError, EOFError):
@@ -169,13 +169,13 @@ class Retrain(AutoTagCommand):
         #       and guarantee these results don't corrupt the somewhat
         #       lame/broken result cache.
         #
-        no_trash = ['-in:%s' % t._key for t in config.get_tags(type='trash')]
+        no_trash = ['-in:{0!s}'.format(t._key) for t in config.get_tags(type='trash')]
         interest = {}
         for ttype in ('replied', 'fwded', 'read', 'tagged'):
             interest[ttype] = set()
             for tag in config.get_tags(type=ttype):
                 interest[ttype] |= idx.search(session,
-                                              ['in:%s' % tag.slug] + no_trash
+                                              ['in:{0!s}'.format(tag.slug)] + no_trash
                                               ).as_set()
             session.ui.notify(_('Have %d interesting %s messages'
                                 ) % (len(interest[ttype]), ttype))
@@ -185,10 +185,10 @@ class Retrain(AutoTagCommand):
         for at_config in config.prefs.autotag:
             at_tag = config.get_tag(at_config.match_tag)
             if at_tag and at_tag._key in tids:
-                session.ui.mark('Retraining: %s' % at_tag.name)
+                session.ui.mark('Retraining: {0!s}'.format(at_tag.name))
 
-                yn = [(set(), set(), 'in:%s' % at_tag.slug, True),
-                      (set(), set(), '-in:%s' % at_tag.slug, False)]
+                yn = [(set(), set(), 'in:{0!s}'.format(at_tag.slug), True),
+                      (set(), set(), '-in:{0!s}'.format(at_tag.slug), False)]
 
                 # Get the current message sets: tagged and untagged messages
                 # excluding trash.
@@ -201,7 +201,7 @@ class Retrain(AutoTagCommand):
                 for etagid in at_config.exclude_tags:
                     etag = config.get_tag(etagid)
                     if etag._key not in interest:
-                        srch = ['in:%s' % etag._key] + no_trash
+                        srch = ['in:{0!s}'.format(etag._key)] + no_trash
                         interest[etag._key] = idx.search(session, srch
                                                          ).as_set()
                     interesting.append(etag._key)
@@ -387,14 +387,14 @@ def filter_hook(session, msg_mid, msg, keywords, **kwargs):
                 if 'autotag' in config.sys.debug:
                     session.ui.debug(('Autotagging %s with %s (w=%s, i=%s)'
                                       ) % (msg_mid, at_tag.name, want, info))
-                keywords.add('%s:in' % at_tag._key)
+                keywords.add('{0!s}:in'.format(at_tag._key))
             elif at_config.unsure_tag and want is None:
                 unsure_tag = config.get_tag(at_config.unsure_tag)
                 if 'autotag' in config.sys.debug:
                     session.ui.debug(('Autotagging %s with %s (w=%s, i=%s)'
                                       ) % (msg_mid, unsure_tag.name,
                                            want, info))
-                keywords.add('%s:in' % unsure_tag._key)
+                keywords.add('{0!s}:in'.format(unsure_tag._key))
         except (KeyError, AttributeError, ValueError):
             pass
 

--- a/mailpile/plugins/crypto_gnupg.py
+++ b/mailpile/plugins/crypto_gnupg.py
@@ -72,8 +72,7 @@ class ContentTxf(EmailTransform):
                 'N': 'unprotected',
                 'CFG': self.config.prefs.openpgp_header
             }[openpgp_header[0].upper()]
-            msg["OpenPGP"] = ("id=%s; preference=%s"
-                              % (sender_keyid, preference))
+            msg["OpenPGP"] = ("id={0!s}; preference={1!s}".format(sender_keyid, preference))
 
         if ('attach-pgp-pubkey' in msg and
                 msg['attach-pgp-pubkey'][:3].lower() in ('yes', 'tru')):
@@ -155,7 +154,7 @@ class GPGKeySearch(Command):
     class CommandResult(Command.CommandResult):
         def as_text(self):
             if self.result:
-                return '\n'.join(["%s: %s <%s>" % (keyid, x["name"], x["email"]) for keyid, det in self.result.iteritems() for x in det["uids"]])
+                return '\n'.join(["{0!s}: {1!s} <{2!s}>".format(keyid, x["name"], x["email"]) for keyid, det in self.result.iteritems() for x in det["uids"]])
             else:
                 return _("No results")
 
@@ -278,7 +277,7 @@ class GPGKeyImportFromMail(Search):
 
         def as_text(self):
             if self.result:
-                return "Imported %d keys (%d updated, %d unchanged) from the mail" % (
+                return "Imported {0:d} keys ({1:d} updated, {2:d} unchanged) from the mail".format(
                     self.result["results"]["count"],
                     self.result["results"]["imported"],
                     self.result["results"]["unchanged"])
@@ -291,7 +290,7 @@ class GPGKeyImportFromMail(Search):
             attid = args.pop()
         else:
             attid = self.data.get("att", 'application/pgp-keys')
-        args.extend(["=%s" % x for x in self.data.get("mid", [])])
+        args.extend(["={0!s}".format(x) for x in self.data.get("mid", [])])
         eids = self._choose_messages(args)
         if len(eids) < 0:
             return self._error("No messages selected", None)
@@ -361,7 +360,7 @@ class GPGUsageStatistics(Search):
 
         def as_text(self):
             if self.result:
-                return "%d%% of e-mail from %s has PGP signatures (%d/%d)" % (
+                return "{0:d}% of e-mail from {1!s} has PGP signatures ({2:d}/{3:d})".format(
                     100*self.result["ratio"],
                     self.result["address"],
                     self.result["pgpsigned"],
@@ -378,12 +377,12 @@ class GPGUsageStatistics(Search):
         if addr is None:
             return self._error("Must supply an address", None)
 
-        session, idx = self._do_search(search=["from:%s" % addr])
+        session, idx = self._do_search(search=["from:{0!s}".format(addr)])
         total = 0
         for messageid in session.results:
             total += 1
 
-        session, idx = self._do_search(search=["from:%s" % addr,  "has:pgp"])
+        session, idx = self._do_search(search=["from:{0!s}".format(addr),  "has:pgp"])
         pgp = 0
         for messageid in session.results:
             pgp += 1
@@ -419,13 +418,13 @@ class GPGCheckKeys(Search):
             if not isinstance(self.result, (dict,)):
                 return ''
             if self.result.get('details'):
-                message = '%s.\n - %s' % (self.message, '\n - '.join(
+                message = '{0!s}.\n - {1!s}'.format(self.message, '\n - '.join(
                     p['description'] for p in self.result['details']
                 ))
             else:
-                message = '%s. %s' % (self.message, _('Looks good!'))
+                message = '{0!s}. {1!s}'.format(self.message, _('Looks good!'))
             if self.result.get('fixes'):
-                message += '\n\n%s\n - %s' % (_('Proposed fixes:'),
+                message += '\n\n{0!s}\n - {1!s}'.format(_('Proposed fixes:'),
                                             '\n - '.join(
                     '\n    * '.join(f) for f in self.result['fixes']
                 ))
@@ -443,14 +442,14 @@ class GPGCheckKeys(Search):
         return [
            _('Update the Mailpile config to use a good key:'),
            _('IMPORTANT: This MUST be done before disabling the key!'),
-           _('Run: %s') % ('`set prefs.gpg_recipient = %s`' % fprint),
+           _('Run: %s') % ('`set prefs.gpg_recipient = {0!s}`'.format(fprint)),
            _('Run: %s') % ('`optimize`'),
            _('This key\'s passphrase will be used to log in to Mailpile')]
 
     def _fix_revoke_key(self, fprint, comment=''):
         return [
             _('Revoke bad keys:') + ('  ' + comment if comment else ''),
-            _('Run: %s') % ('`gpg --gen-revoke %s`' % fprint),
+            _('Run: %s') % ('`gpg --gen-revoke {0!s}`'.format(fprint)),
             _('Say yes to the first question, follow the instructions'),
             _('A revocation certificate will be shown on screen'),
             _('Copy & paste that, save, and send to people who have the old key'),
@@ -460,7 +459,7 @@ class GPGCheckKeys(Search):
     def _fix_disable_key(self, fprint, comment=''):
         return [
             _('Disable bad keys:') + ('  ' + comment if comment else ''),
-            _('Run: %s') % ('`gpg --edit-key %s`' % fprint),
+            _('Run: %s') % ('`gpg --edit-key {0!s}`'.format(fprint)),
             _('Type %s') % '`disable`',
             _('Type %s') % '`save`']
 

--- a/mailpile/plugins/crypto_policy.py
+++ b/mailpile/plugins/crypto_policy.py
@@ -37,8 +37,8 @@ class UpdateCryptoPolicyForUser(CryptoPolicyBaseAction):
         email, policy = self._parse_args()
 
         if policy not in CRYPTO_POLICIES:
-            return self._error('Policy has to be one of %s' %
-                               '|'.join(CRYPTO_POLICIES))
+            return self._error('Policy has to be one of {0!s}'.format(
+                               '|'.join(CRYPTO_POLICIES)))
 
         vcard = self.session.config.vcards.get_vcard(email)
         if vcard:

--- a/mailpile/plugins/cryptostate.py
+++ b/mailpile/plugins/cryptostate.py
@@ -22,13 +22,13 @@ def meta_kw_extractor(index, msg_mid, msg, msg_size, msg_ts, **kwargs):
     def crypto_eval(part):
         # This is generic
         if part.encryption_info.get('status') != 'none':
-            enc.add('mp_%s-%s' % ('enc', part.encryption_info['status']))
+            enc.add('mp_{0!s}-{1!s}'.format('enc', part.encryption_info['status']))
             kw.add('crypto:has')
         if part.signature_info.get('status') != 'none':
-            sig.add('mp_%s-%s' % ('sig', part.signature_info['status']))
+            sig.add('mp_{0!s}-{1!s}'.format('sig', part.signature_info['status']))
             kw.add('crypto:has')
         if 'cryptostate' in index.config.sys.debug:
-            print 'part status(=%s): enc=%s sig=%s' % (msg_mid,
+            print 'part status(={0!s}): enc={1!s} sig={2!s}'.format(msg_mid,
                 part.encryption_info.get('status'),
                 part.signature_info.get('status')
             )
@@ -69,10 +69,10 @@ def meta_kw_extractor(index, msg_mid, msg, msg_size, msg_ts, **kwargs):
     for tname in (enc | sig):
         tag = index.config.get_tags(slug=tname)
         if tag:
-            kw.add('%s:in' % tag[0]._key)
+            kw.add('{0!s}:in'.format(tag[0]._key))
 
     if 'cryptostate' in index.config.sys.debug:
-        print 'part crypto state(=%s): %s' % (msg_mid, ','.join(list(kw)))
+        print 'part crypto state(={0!s}): {1!s}'.format(msg_mid, ','.join(list(kw)))
 
     return list(kw)
 

--- a/mailpile/plugins/dates.py
+++ b/mailpile/plugins/dates.py
@@ -14,11 +14,11 @@ _plugins = PluginManager(builtin=__name__)
 def meta_kw_extractor(index, msg_mid, msg, msg_size, msg_ts, **kwargs):
     mdate = datetime.date.fromtimestamp(msg_ts)
     keywords = [
-        '%s:year' % mdate.year,
-        '%s:month' % mdate.month,
-        '%s:day' % mdate.day,
-        '%s-%s:yearmonth' % (mdate.year, mdate.month),
-        '%s-%s-%s:date' % (mdate.year, mdate.month, mdate.day)
+        '{0!s}:year'.format(mdate.year),
+        '{0!s}:month'.format(mdate.month),
+        '{0!s}:day'.format(mdate.day),
+        '{0!s}-{1!s}:yearmonth'.format(mdate.year, mdate.month),
+        '{0!s}-{1!s}-{2!s}:date'.format(mdate.year, mdate.month, mdate.day)
     ]
     return keywords
 
@@ -38,7 +38,7 @@ def _adjust(d):
 
 def _mk_date(ts):
     mdate = datetime.date.fromtimestamp(ts)
-    return '%d-%d-%d' % (mdate.year, mdate.month, mdate.day)
+    return '{0:d}-{1:d}-{2:d}'.format(mdate.year, mdate.month, mdate.day)
 
 
 _date_offsets = {
@@ -77,7 +77,7 @@ def search(config, idx, term, hits):
             if start[1:] == [1, 1]:
                 ny = [start[0], 12, 31]
                 if ny <= end:
-                    terms.append('%d:year' % start[0])
+                    terms.append('{0:d}:year'.format(start[0]))
                     start[0] += 1
                     continue
 
@@ -85,13 +85,13 @@ def search(config, idx, term, hits):
             if start[2] == 1:
                 nm = [start[0], start[1], 31]
                 if nm <= end:
-                    terms.append('%d-%d:yearmonth' % (start[0], start[1]))
+                    terms.append('{0:d}-{1:d}:yearmonth'.format(start[0], start[1]))
                     start[1] += 1
                     _adjust(start)
                     continue
 
             # Move forward one day...
-            terms.append('%d-%d-%d:date' % tuple(start))
+            terms.append('{0:d}-{1:d}-{2:d}:date'.format(*tuple(start)))
             start[2] += 1
             _adjust(start)
 
@@ -100,7 +100,7 @@ def search(config, idx, term, hits):
             rt.extend(hits(t))
         return rt
     except:
-        raise ValueError('Invalid date range: %s' % term)
+        raise ValueError('Invalid date range: {0!s}'.format(term))
 
 
 _plugins.register_search_term('dates', search)

--- a/mailpile/plugins/eventlog.py
+++ b/mailpile/plugins/eventlog.py
@@ -62,7 +62,7 @@ class Events(Command):
                 try:
                     limit = int(arg)
                 except ValueError:
-                    raise UsageError('Bad argument: %s' % arg)
+                    raise UsageError('Bad argument: {0!s}'.format(arg))
 
         # Handle args from the web
         def fset(arg, val):
@@ -76,7 +76,7 @@ class Events(Command):
             elif arg in ('data', 'private_data'):
                 for data in self.data[arg]:
                     var, val = data.split(':', 1)
-                    fset('%s_%s' % (arg, var), val)
+                    fset('{0!s}_{1!s}'.format(arg, var), val)
 
         # Compile regular expression matches
         for arg in filters:

--- a/mailpile/plugins/exporters.py
+++ b/mailpile/plugins/exporters.py
@@ -35,7 +35,7 @@ class ExportMail(Command):
 
     def export_path(self, mbox_type):
         if mbox_type == 'mbox':
-            return 'mailpile-%d.mbx' % time.time()
+            return 'mailpile-{0:d}.mbx'.format(time.time())
         else:
             return 'mailpile-%d'
 
@@ -44,8 +44,7 @@ class ExportMail(Command):
             return mailbox.mbox(path)
         elif mbox_type == 'maildir':
             return mailbox.Maildir(path)
-        raise UsageError('Invalid mailbox type: %s (must be mbox or maildir)'
-                         % mbox_type)
+        raise UsageError('Invalid mailbox type: {0!s} (must be mbox or maildir)'.format(mbox_type))
 
     def command(self, save=True):
         session, config, idx = self.session, self.session.config, self._idx()
@@ -66,7 +65,7 @@ class ExportMail(Command):
                 notags = True
 
         if os.path.exists(path):
-            return self._error('Already exists: %s' % path)
+            return self._error('Already exists: {0!s}'.format(path))
 
         msg_idxs = list(self._choose_messages(args))
         if not msg_idxs:

--- a/mailpile/plugins/groups.py
+++ b/mailpile/plugins/groups.py
@@ -23,7 +23,7 @@ def search(config, idx, term, hits):
                 emails.append(email.lower())
     fromto = term.startswith('group:') and 'from' or 'to'
     for email in set(emails):
-        rt.extend(hits('%s:%s' % (email, fromto)))
+        rt.extend(hits('{0!s}:{1!s}'.format(email, fromto)))
     return rt
 
 _plugins.register_search_term('group', search)
@@ -51,16 +51,16 @@ def GroupVCard(parent):
         def _prepare_new_vcard(self, vcard):
             session, handle = self.session, vcard.nickname
             return (AddTag(session, arg=[handle]).run() and
-                    Filter(session, arg=['add', 'group:%s' % handle,
-                                         '+%s' % handle, vcard.fn]).run())
+                    Filter(session, arg=['add', 'group:{0!s}'.format(handle),
+                                         '+{0!s}'.format(handle), vcard.fn]).run())
 
         def _add_from_messages(self):
-            raise ValueError('Invalid group ids: %s' % self.args)
+            raise ValueError('Invalid group ids: {0!s}'.format(self.args))
 
         def _pre_delete_vcard(self, vcard):
             session, handle = self.session, vcard.nickname
             return (Filter(session, arg=['delete',
-                                         'group:%s' % handle]).run() and
+                                         'group:{0!s}'.format(handle)]).run() and
                     DeleteTag(session, arg=[handle]).run())
 
     return GroupVCardCommand

--- a/mailpile/plugins/html_magic.py
+++ b/mailpile/plugins/html_magic.py
@@ -149,7 +149,7 @@ class HttpProxyGetRequest(Command):
 
         try:
             with ConnBroker.context(need=conn_need, reject=conn_reject) as ctx:
-                self.session.ui.mark('Getting: %s' % url)
+                self.session.ui.mark('Getting: {0!s}'.format(url))
                 response = urlopen(url, data=None, timeout=timeout)
         except HTTPError, e:
             response = e

--- a/mailpile/plugins/keylookup/__init__.py
+++ b/mailpile/plugins/keylookup/__init__.py
@@ -77,7 +77,7 @@ def _update_scores(key_id, key_info, known_keys_list):
 
     sc, reason = max([(abs(score), reason)
                      for score, reason in key_info['scores'].values()])
-    key_info['score_reason'] = '%s' % reason
+    key_info['score_reason'] = '{0!s}'.format(reason)
 
     log_score = math.log(3 * abs(key_info['score']), 3)
     key_info['score_stars'] = (max(1, min(int(round(log_score)), 5))

--- a/mailpile/plugins/keylookup/email_keylookup.py
+++ b/mailpile/plugins/keylookup/email_keylookup.py
@@ -63,7 +63,7 @@ def _get_keydata(data):
         try:
             if isinstance(m, pgpdump.packet.PublicKeyPacket):
                 size = str(int(1.024 *
-                               round(len('%x' % (m.modulus or 0)) / 0.256)))
+                               round(len('{0:x}'.format((m.modulus or 0))) / 0.256)))
                 validity = ('e'
                             if (0 < (int(m.expiration_time or 0)) < now)
                             else '')
@@ -108,7 +108,7 @@ class EmailKeyLookupHandler(LookupHandler, Search):
     def _lookup(self, address, strict_email_match=False):
         results = {}
         address = address.lower()
-        terms = ['from:%s' % address, 'has:pgpkey', '+pgpkey:%s' % address]
+        terms = ['from:{0!s}'.format(address), 'has:pgpkey', '+pgpkey:{0!s}'.format(address)]
         session, idx = self._do_search(search=terms)
         deadline = time.time() + (0.75 * self.TIMEOUT)
         for messageid in session.results[:5]:
@@ -156,7 +156,7 @@ def has_pgpkey_data_kw_extractor(index, msg, mimetype, filename, part, loader,
         for keydata in data:
             for uid in keydata.get('uids', []):
                 if uid.get('email'):
-                    kws.append('%s:pgpkey' % uid['email'].lower())
+                    kws.append('{0!s}:pgpkey'.format(uid['email'].lower()))
         if data:
             body_info['pgp_key'] = filename
             kws += ['pgpkey:has']

--- a/mailpile/plugins/keylookup/nicknym.py
+++ b/mailpile/plugins/keylookup/nicknym.py
@@ -115,7 +115,7 @@ class Nicknym:
         addr = address.split("@")
         addr.reverse()
         domain = addr[0]
-        return "https://nicknym.%s:6425/" % domain
+        return "https://nicknym.{0!s}:6425/".format(domain)
 
     def _audit_key(self, address, keytype, server):
         """

--- a/mailpile/plugins/motd.py
+++ b/mailpile/plugins/motd.py
@@ -78,7 +78,7 @@ class MessageOfTheDay(Command):
             return _('Unsupported URL for message of the day: %s') % url
 
         with ConnBroker.context(need=conn_need) as ctx:
-            self.session.ui.mark('Getting: %s' % url)
+            self.session.ui.mark('Getting: {0!s}'.format(url))
             return urlopen(url, data=None, timeout=10).read()
 
     class CommandResult(Command.CommandResult):
@@ -88,7 +88,7 @@ class MessageOfTheDay(Command):
                 return ''
 
             date = dtime.fromtimestamp(self.result.get('timestamp', 0))
-            return '%s, %4.4d-%2.2d-%2.2d:\n\n    %s\n\n*** %s ***\n' % (
+            return '{0!s}, {1:4.4d}-{2:2.2d}-{3:2.2d}:\n\n    {4!s}\n\n*** {5!s} ***\n'.format(
                 _('Message Of The Day'),
                 date.year, date.month, date.day,
                 motd.replace('\n', '\n    '),
@@ -106,7 +106,7 @@ class MessageOfTheDay(Command):
         old_motd = motd = None
         try:
             old_motd = motd = config.load_pickle('last_motd')
-            message = '%s: %s' % (_('Message Of The Day'), _('Loaded'))
+            message = '{0!s}: {1!s}'.format(_('Message Of The Day'), _('Loaded'))
         except (OSError, IOError):
             pass
 
@@ -134,7 +134,7 @@ class MessageOfTheDay(Command):
                         or old_motd.get("timestamp") != motd.get("timestamp")):
                     config.save_pickle(motd, 'last_motd', encrypt=False)
                     motd['_is_new'] = True
-                    message = '%s: %s' % (_('Message Of The Day'), _('Updated'))
+                    message = '{0!s}: {1!s}'.format(_('Message Of The Day'), _('Updated'))
             except (IOError, OSError, ValueError):
                 pass
 
@@ -164,7 +164,7 @@ class MessageOfTheDay(Command):
 
             return self._success(message, result=motd)
         else:
-            message = '%s: %s' % (_('Message Of The Day'), _('Unknown'))
+            message = '{0!s}: {1!s}'.format(_('Message Of The Day'), _('Unknown'))
             return self._error(message, result={})
 
 

--- a/mailpile/plugins/search.py
+++ b/mailpile/plugins/search.py
@@ -109,7 +109,7 @@ class Search(Command):
                 try:
                     raw_tag = session.config.get_tag(t.split(':')[1])
                     if raw_tag and raw_tag.hasattr(slug):
-                        t = 'in:%s' % raw_tag.slug
+                        t = 'in:{0!s}'.format(raw_tag.slug)
                 except (IndexError, KeyError, TypeError):
                     pass
             return p+t
@@ -132,12 +132,12 @@ class Search(Command):
         d_start = int(self.data.get('start', [0])[0])
         d_end = int(self.data.get('end', [0])[0])
         if d_start and d_end:
-            args[:0] = ['@%s' % d_start]
+            args[:0] = ['@{0!s}'.format(d_start)]
             num = d_end - d_start + 1
         elif d_start:
-            args[:0] = ['@%s' % d_start]
+            args[:0] = ['@{0!s}'.format(d_start)]
         elif d_end:
-            args[:0] = ['@%s' % (d_end - num + 1)]
+            args[:0] = ['@{0!s}'.format((d_end - num + 1))]
 
         start = 0
         self._default_position = True
@@ -257,11 +257,11 @@ class Search(Command):
             return unicode(term)
         reqs = set(['!config'] +
                    [fix_term(t) for t in self.session.searched] +
-                   [u'%s:msg' % i for i in msgs])
+                   [u'{0!s}:msg'.format(i) for i in msgs])
         if self.session.displayed:
-            reqs |= set(u'%s:thread' % int(tmid, 36) for tmid in
+            reqs |= set(u'{0!s}:thread'.format(int(tmid, 36)) for tmid in
                         self.session.displayed.get('thread_ids', []))
-            reqs |= set(u'%s:msg' % int(tmid, 36) for tmid in
+            reqs |= set(u'{0!s}:msg'.format(int(tmid, 36)) for tmid in
                         self.session.displayed.get('message_ids', []))
         return reqs
 
@@ -359,7 +359,7 @@ class View(Search):
             return self._decode()
 
         def as_html(self, *args, **kwargs):
-            return '<pre>%s</pre>' % escape_html(self._decode())
+            return '<pre>{0!s}</pre>'.format(escape_html(self._decode()))
 
     def _side_effects(self, emails):
         # A compatibility stub only
@@ -372,7 +372,7 @@ class View(Search):
         session, config, idx = self.session, self.session.config, self._idx()
         results = []
         args = list(self.args)
-        args.extend(['=%s' % mid.replace('=', '')
+        args.extend(['={0!s}'.format(mid.replace('=', ''))
                      for mid in self.data.get('mid', [])])
         if args and args[0].lower() == 'raw':
             raw = args.pop(0)
@@ -483,7 +483,7 @@ class Extract(Command):
         for e in emails:
             if cid[0] == '*':
                 tree = e.get_message_tree(want=['attachments'])
-                cids = [('#%s' % a['count']) for a in tree['attachments']
+                cids = [('#{0!s}'.format(a['count'])) for a in tree['attachments']
                         if a['filename'].lower().endswith(cid[1:].lower())]
             else:
                 cids = [cid]
@@ -520,7 +520,7 @@ def mailbox_search(config, idx, term, hits):
     rt = []
     for mbox_id in mailboxes:
         mbox_id = FormatMbxId(mbox_id)
-        rt.extend(hits('%s:mailbox' % mbox_id))
+        rt.extend(hits('{0!s}:mailbox'.format(mbox_id)))
 
     return rt
 

--- a/mailpile/plugins/setup_magic.py
+++ b/mailpile/plugins/setup_magic.py
@@ -220,7 +220,7 @@ class SetupMagic(Command):
                 session.config.filters.append({
                     'type': 'system',
                     'terms': search,
-                    'tags': '+%s' % tid,
+                    'tags': '+{0!s}'.format(tid),
                     'primary_tag': tid,
                     'comment': t
                 })
@@ -234,7 +234,7 @@ class SetupMagic(Command):
         for stype, statuses in (('sig', SignatureInfo.STATUSES),
                                 ('enc', EncryptionInfo.STATUSES)):
             for status in statuses:
-                tagname = 'mp_%s-%s' % (stype, status)
+                tagname = 'mp_{0!s}-{1!s}'.format(stype, status)
                 if not session.config.get_tag_id(tagname):
                     AddTag(session, arg=[tagname]).run(save=False)
                     created.append(tagname)
@@ -333,9 +333,9 @@ class SetupMagic(Command):
             #   math.log((25 + 25 + 8) ** (12 * 4), 2) == 281.183...
             #
             session.config.master_key = okay_random(12 * 4,
-                                                    '%s' % session.config,
-                                                    '%s' % self.session,
-                                                    '%s' % self.data)
+                                                    '{0!s}'.format(session.config),
+                                                    '{0!s}'.format(self.session),
+                                                    '{0!s}'.format(self.data))
             if self._idx() and self._idx().INDEX:
                 session.ui.warning(_('Unable to obfuscate search index '
                                      'without losing data. Not indexing '
@@ -372,15 +372,15 @@ class TestableWebbable(SetupMagic):
 
         nxt = Setup.Next(self.session.config, None, needed_auth=False)
         if nxt:
-            url = '/%s/' % nxt.SYNOPSIS[2]
-        elif path and path != '/%s/' % Setup.SYNOPSIS[2]:
+            url = '/{0!s}/'.format(nxt.SYNOPSIS[2])
+        elif path and path != '/{0!s}/'.format(Setup.SYNOPSIS[2]):
             # Use the same redirection logic as the Authenticator
             mailpile.auth.Authenticate.RedirectBack(path, data)
         else:
             url = '/'
 
         qs = urlencode([(k, v) for k, vl in data.iteritems() for v in vl])
-        raise UrlRedirectException(''.join([self.session.config.sys.http_path, url, '?%s' % qs if qs else '']))
+        raise UrlRedirectException(''.join([self.session.config.sys.http_path, url, '?{0!s}'.format(qs) if qs else '']))
 
     def _success(self, message, result=True, advance=False):
         if advance or truthy(self.data.get('advance', ['no'])[0], default=False):
@@ -460,7 +460,7 @@ class SetupGetEmailSettings(TestableWebbable):
         else:
             conn_needs = [ConnBroker.OUTGOING_HTTP]
         with ConnBroker.context(need=conn_needs) as context:
-            self.session.ui.mark('Getting: %s' % url)
+            self.session.ui.mark('Getting: {0!s}'.format(url))
             return urlopen(url, data=None, timeout=10).read()
 
     def _username(self, val, email):
@@ -476,7 +476,7 @@ class SetupGetEmailSettings(TestableWebbable):
         elif sockettype.lower() == 'starttls':
             servertype += '_tls'
         else:
-            print 'FIXME/SOURCE: %s/%s' % (sockettype, servertype)
+            print 'FIXME/SOURCE: {0!s}/{1!s}'.format(sockettype, servertype)
         return servertype.lower()
 
     def _route_proto(self, outsrv):
@@ -487,7 +487,7 @@ class SetupGetEmailSettings(TestableWebbable):
         elif sockettype.lower() == 'starttls':
             servertype += 'tls'
         else:
-            print 'FIXME/ROUTE: %s/%s' % (sockettype, servertype)
+            print 'FIXME/ROUTE: {0!s}/{1!s}'.format(sockettype, servertype)
         return servertype.lower()
 
     def _rank(self, entry):
@@ -647,7 +647,7 @@ class SetupGetEmailSettings(TestableWebbable):
                                (None, ('imap', 'pop3', 'smtp'))):
             try:
                 if prefix:
-                    name = '%s.%s' % (prefix, domain)
+                    name = '{0!s}.{1!s}'.format(prefix, domain)
                 else:
                     name = domain
 
@@ -656,7 +656,7 @@ class SetupGetEmailSettings(TestableWebbable):
                 else:
                     # We just try to connect to everything if anonymity
                     # was requested - otherwise we'd be leaking over DNS.
-                    ip = '%s-%s' % (prefix, protos)
+                    ip = '{0!s}-{1!s}'.format(prefix, protos)
 
                 if ip:
                     for proto in protos:
@@ -1070,7 +1070,7 @@ class SetupTestRoute(TestableWebbable):
         if '@' not in fromaddr:
             fromaddr = self.session.config.get_profile()['email']
         if not fromaddr or '@' not in fromaddr:
-            fromaddr = '%s@%s' % (route.get('username', 'test'),
+            fromaddr = '{0!s}@{1!s}'.format(route.get('username', 'test'),
                                   route.get('host', 'example.com'))
         assert(fromaddr)
 

--- a/mailpile/plugins/sizes.py
+++ b/mailpile/plugins/sizes.py
@@ -16,7 +16,7 @@ def meta_kw_extractor(index, msg_mid, msg, msg_size, msg_ts, **kwargs):
     """Create a search term with the floored log2 size of the message."""
     if msg_size <= 0:
         return []
-    return ['%s:ln2sz' % int(math.log(msg_size, 2))]
+    return ['{0!s}:ln2sz'.format(int(math.log(msg_size, 2)))]
 
 _plugins.register_meta_kw_extractor('sizes', meta_kw_extractor)
 
@@ -75,14 +75,14 @@ def search(config, idx, term, hits):
 
         start = _mk_logsize(start, end_unit)
         end = _mk_logsize(end)
-        terms = ['%s:ln2sz' % sz for sz in range(start, end+1)]
+        terms = ['{0!s}:ln2sz'.format(sz) for sz in range(start, end+1)]
 
         rt = []
         for t in terms:
             rt.extend(hits(t))
         return rt
     except:
-        raise ValueError('Invalid size: %s' % term)
+        raise ValueError('Invalid size: {0!s}'.format(term))
 
 
 _plugins.register_search_term('size', search)

--- a/mailpile/plugins/smtp_server.py
+++ b/mailpile/plugins/smtp_server.py
@@ -80,7 +80,7 @@ class SMTPChannel(smtpd.SMTPChannel):
             solution = None
 
         want_bits = self.HASHCASH_WANT_BITS
-        addrpair = '%s, %s' % (self.__mailfrom, address)
+        addrpair = '{0!s}, {1!s}'.format(self.__mailfrom, address)
         if solution and addrpair in self.want_hashcash:
             if sha512_512kCheck(self.want_hashcash[addrpair],
                                want_bits, solution):
@@ -212,8 +212,7 @@ class HashCash(Command):
         expected = 2 ** bits
         def marker(counter):
             progress = ((1024.0 * counter) / expected) * 100
-            self.session.ui.mark('Finding a %d-bit collision for %s (%d%%)'
-                                 % (bits, challenge, progress))
+            self.session.ui.mark('Finding a {0:d}-bit collision for {1!s} ({2:d}%)'.format(bits, challenge, progress))
         collision = sha512_512kCollide(challenge, bits, callback1k=marker)
         return self._success({
             'challenge': challenge,

--- a/mailpile/plugins/vcard_carddav.py
+++ b/mailpile/plugins/vcard_carddav.py
@@ -28,14 +28,14 @@ class DAVClient:
                 raise Exception("Can't determine port from protocol. "
                                 "Please specifiy a port.")
         self.cwd = "/"
-        self.baseurl = "%s://%s:%d" % (protocol, host, port)
+        self.baseurl = "{0!s}://{1!s}:{2:d}".format(protocol, host, port)
         self.host = host
         self.port = port
         self.protocol = protocol
         self.username = username
         self.password = password
         if username and password:
-            self.auth = base64.encodestring('%s:%s' % (username, password)
+            self.auth = base64.encodestring('{0!s}:{1!s}'.format(username, password)
                                             ).replace('\n', '')
         else:
             self.auth = None
@@ -51,7 +51,7 @@ class DAVClient:
         req.putheader("Host", self.host)
         req.putheader("User-Agent", "Mailpile")
         if self.auth:
-            req.putheader("Authorization", "Basic %s" % self.auth)
+            req.putheader("Authorization", "Basic {0!s}".format(self.auth))
 
         for key, value in headers.iteritems():
             req.putheader(key, value)

--- a/mailpile/plugins/vcard_gnupg.py
+++ b/mailpile/plugins/vcard_gnupg.py
@@ -35,7 +35,7 @@ class GnuPGImporter(VCardImporter):
     UPDATE_INDEX = True
 
     def get_guid(self, vcard):
-        return '%s/%s' % (self.config.guid, vcard.get('x-gpg-mrgid').value)
+        return '{0!s}/{1!s}'.format(self.config.guid, vcard.get('x-gpg-mrgid').value)
 
     def import_vcards(self, session, vcard_store, *args, **kwargs):
         kwargs['vcards'] = vcard_store
@@ -62,7 +62,7 @@ class GnuPGImporter(VCardImporter):
         if vcards:
             deleted = set()
             deleted_names = {}
-            search = ';%s/' % self.config.guid
+            search = ';{0!s}/'.format(self.config.guid)
             for cardid, vcard in (vcards or {}).iteritems():
                 for vcl in vcard.get_all('clientpidmap'):
                     if search in vcl.value:

--- a/mailpile/plugins/vcard_gravatar.py
+++ b/mailpile/plugins/vcard_gravatar.py
@@ -66,7 +66,7 @@ class GravatarImporter(VCardImporter):
         return want
 
     def _get(self, url):
-        self.session.ui.mark('Getting: %s' % url)
+        self.session.ui.mark('Getting: {0!s}'.format(url))
         return secure_urlget(self.session, url,
                              timeout=5,
                              anonymous=self.config.anonymous)
@@ -142,7 +142,7 @@ class GravatarImporter(VCardImporter):
             if img:
                 vcard.add(VCardLine(
                     name='photo',
-                    value='data:image/jpeg;base64,%s' % _b64(img),
+                    value='data:image/jpeg;base64,{0!s}'.format(_b64(img)),
                     mediatype='image/jpeg'
                 ))
 

--- a/mailpile/plugins/vcard_libravatar.py
+++ b/mailpile/plugins/vcard_libravatar.py
@@ -65,7 +65,7 @@ class LibravatarImporter(VCardImporter):
         return want
 
     def _get(self, url):
-        self.session.ui.mark('Getting: %s' % url)
+        self.session.ui.mark('Getting: {0!s}'.format(url))
         return secure_urlget(self.session, url,
                              timeout=5,
                              anonymous=self.config.anonymous)
@@ -141,7 +141,7 @@ class LibravatarImporter(VCardImporter):
             if img:
                 vcard.add(VCardLine(
                     name='photo',
-                    value='data:image/jpeg;base64,%s' % _b64(img),
+                    value='data:image/jpeg;base64,{0!s}'.format(_b64(img)),
                     mediatype='image/jpeg'
                 ))
 

--- a/mailpile/plugins/vcard_mork.py
+++ b/mailpile/plugins/vcard_mork.py
@@ -90,7 +90,7 @@ class MorkImporter(VCardImporter):
             return '\\r'
         if s == '\n':
             return '\\n'
-        return "\\x%02x" % ord(s)
+        return "\\x{0:02x}".format(ord(s))
 
     def encodeMindyValue(self, value):
         return self.pMindyEscape.sub(self.escapeMindy, value)
@@ -170,7 +170,7 @@ class MorkImporter(VCardImporter):
             rowkey = row.id + "/" + table.scope
 
         if rowkey in table.rows:
-            print >>stderr, "ERROR: duplicate rowid/scope %s" % rowkey
+            print >>stderr, "ERROR: duplicate rowid/scope {0!s}".format(rowkey)
             print >>stderr, cells
 
         table.rows[rowkey] = row
@@ -299,7 +299,7 @@ class MorkImporter(VCardImporter):
 
             # Syntax error
             print >>stderr, "ERROR: syntax error while parsing MORK file"
-            print >>stderr, "context[%d]: %s" % (index, sub[:40])
+            print >>stderr, "context[{0:d}]: {1!s}".format(index, sub[:40])
             index += 1
 
         # Return the database

--- a/mailpile/postinglist.py
+++ b/mailpile/postinglist.py
@@ -151,7 +151,7 @@ class PostingListContainer(object):
                                         delimited=False,
                                         dir=self.config.tempfile_dir(),
                                         header_data={'subject': subj},
-                                        name='PLC/%s' % self.sig) as fd:
+                                        name='PLC/{0!s}'.format(self.sig)) as fd:
                     fd.write(output)
                     fd.save(outfile)
             else:
@@ -218,8 +218,7 @@ class PostingListContainer(object):
                                         self.config)
                 self.changes = 0
             except (ValueError, IOError):
-                self.session.ui.warning('load(%s) %s'
-                                        % (self.sig, sys.exc_info()))
+                self.session.ui.warning('load({0!s}) {1!s}'.format(self.sig, sys.exc_info()))
                 if self.config.sys.debug:
                     traceback.print_exc()
         self.fd = None
@@ -339,7 +338,7 @@ class OldPostingList(object):
                     break
                 filesize = os.path.getsize(os.path.join(postinglist_dir, fn))
                 if force or (filesize > 900 * postinglist_kb):
-                    session.ui.mark('Pass 1: Compacting >%s<' % fn)
+                    session.ui.mark('Pass 1: Compacting >{0!s}<'.format(fn))
                     play_nice_with_threads()
                     with GLOBAL_POSTING_LOCK:
                         # FIXME: Remove invalid and deleted messages from
@@ -361,7 +360,7 @@ class OldPostingList(object):
                 size += os.path.getsize(os.path.join(postinglist_dir, fnp))
                 if (fnp and
                     size < (1024 * postinglist_kb - (cls.HASH_LEN * 6))):
-                    session.ui.mark('Pass 2: Merging %s into %s' % (fn, fnp))
+                    session.ui.mark('Pass 2: Merging {0!s} into {1!s}'.format(fn, fnp))
                     play_nice_with_threads()
                     try:
                         GLOBAL_POSTING_LOCK.acquire()
@@ -381,7 +380,7 @@ class OldPostingList(object):
         filecount = 0
         for c in cls.CHARACTERS:
             filecount += len(os.listdir(session.config.postinglist_dir(c)))
-        session.ui.mark('Optimized %s posting lists' % filecount)
+        session.ui.mark('Optimized {0!s} posting lists'.format(filecount))
         return filecount
 
     @classmethod
@@ -404,11 +403,10 @@ class OldPostingList(object):
                         break
                 if fd:
                     with fd:
-                        fd.write('%s\t%s\n' % (sig, '\t'.join(mail_ids)))
+                        fd.write('{0!s}\t{1!s}\n'.format(sig, '\t'.join(mail_ids)))
                         return
             except IOError:
-                print ('RETRY: APPEND(compact=%s, %s, %s) %s'
-                       % (compact, fn_path, fd, sys.exc_info()))
+                print ('RETRY: APPEND(compact={0!s}, {1!s}, {2!s}) {3!s}'.format(compact, fn_path, fd, sys.exc_info()))
                 time.sleep(0.2)
                 fd = None
 
@@ -493,18 +491,17 @@ class OldPostingList(object):
                 self.size = 0
                 decrypt_and_parse_lines(fd, self._parse_lines, self.config)
             except (ValueError, IOError):
-                self.session.ui.warning('load(%s) %s'
-                                        % (self.filename, sys.exc_info()))
+                self.session.ui.warning('load({0!s}) {1!s}'.format(self.filename, sys.exc_info()))
 
     def _fmt_file(self, prefix):
         output = []
-        self.session.ui.mark('Formatting prefix %s' % unicode(prefix))
+        self.session.ui.mark('Formatting prefix {0!s}'.format(unicode(prefix)))
         for word in self.WORDS.keys():
             data = self.WORDS.get(word, [])
             if ((prefix == 'ALL' or word.startswith(prefix))
                     and len(data) > 0):
                 output.append(('%s\t%s\n'
-                               ) % (word, '\t'.join(['%s' % x for x in data])))
+                               ) % (word, '\t'.join(['{0!s}'.format(x) for x in data])))
         play_nice_with_threads(weak=True)
         return ''.join(output)
 
@@ -534,7 +531,7 @@ class OldPostingList(object):
                 prefix, output = self._compact(prefix, output)
             try:
                 outfile = self.SaveFile(self.session, prefix)
-                self.session.ui.mark('Writing %d bytes to %s' % (len(output),
+                self.session.ui.mark('Writing {0:d} bytes to {1!s}'.format(len(output),
                                                                  outfile))
                 if output:
                     if self.config.prefs.encrypt_index:
@@ -552,7 +549,7 @@ class OldPostingList(object):
                 elif os.path.exists(outfile):
                     os.remove(outfile)
             except:
-                self.session.ui.warning('%s=>%s' % (outfile, sys.exc_info(),))
+                self.session.ui.warning('{0!s}=>{1!s}'.format(outfile, sys.exc_info()))
             return 0
 
     def hits(self):

--- a/mailpile/search.py
+++ b/mailpile/search.py
@@ -258,7 +258,7 @@ class MailIndex(object):
                             if session and len(self.INDEX) % 107 == 100:
                                 session.ui.mark(
                                     _('Loading metadata index...') +
-                                    ' %s' % len(self.INDEX))
+                                    ' {0!s}'.format(len(self.INDEX)))
                         except ValueError:
                             bogus = True
 
@@ -300,7 +300,7 @@ class MailIndex(object):
 
         if bogus_lines:
             bogus_file = (self.config.mailindex_file() +
-                          '.bogus.%x' % time.time())
+                          '.bogus.{0:x}'.format(time.time()))
             with open(bogus_file, 'w') as bl:
                 bl.write('\n'.join(bogus_lines))
             if session:
@@ -368,7 +368,7 @@ class MailIndex(object):
                 emails = []
                 for eid in range(old_emails_saved, total):
                     quoted_email = quote(self.EMAILS[eid].encode('utf-8'))
-                    emails.append('@%s\t%s\n' % (b36(eid), quoted_email))
+                    emails.append('@{0!s}\t{1!s}\n'.format(b36(eid), quoted_email))
                 self.EMAILS_SAVED = total
 
             # Unlocked, try to write this out
@@ -400,16 +400,16 @@ class MailIndex(object):
                 session.ui.mark(_("Saving metadata index..."))
 
             idxfile = self.config.mailindex_file()
-            newfile = '%s.new' % idxfile
+            newfile = '{0!s}.new'.format(idxfile)
 
             data = [
                 '# This is the mailpile.py index file.\n',
-                '# We have %d messages!\n' % len(self.INDEX)
+                '# We have {0:d} messages!\n'.format(len(self.INDEX))
             ]
             self.EMAILS_SAVED = email_counter = len(self.EMAILS)
             for eid in range(0, email_counter):
                 quoted_email = quote(self.EMAILS[eid].encode('utf-8'))
-                data.append('@%s\t%s\n' % (b36(eid), quoted_email))
+                data.append('@{0!s}\t{1!s}\n'.format(b36(eid), quoted_email))
             index_counter = len(self.INDEX)
             for i in range(0, index_counter):
                 data.append(self.INDEX[i] + '\n')
@@ -541,7 +541,7 @@ class MailIndex(object):
 
     def _update_location(self, session, msg_idx_pos, msg_ptr):
         if 'rescan' in session.config.sys.debug:
-            session.ui.debug('Moved? %s -> %s' % (b36(msg_idx_pos), msg_ptr))
+            session.ui.debug('Moved? {0!s} -> {1!s}'.format(b36(msg_idx_pos), msg_ptr))
 
         msg_info = self.get_msg_at_idx_pos(msg_idx_pos)
         msg_ptrs = msg_info[self.MSG_PTRS].split(',')
@@ -626,7 +626,7 @@ class MailIndex(object):
     def encode_msg_id(self, msg_id):
         # Discard any data seen outside the first angle-brackets
         if '<' in msg_id:
-            new_msg_id = '<%s>' % msg_id.split('<')[1].split('>')[0]
+            new_msg_id = '<{0!s}>'.format(msg_id.split('<')[1].split('>')[0])
             if len(new_msg_id) > 2:
                 msg_id = new_msg_id
         return b64c(sha1b64(msg_id.strip()))
@@ -821,7 +821,7 @@ class MailIndex(object):
     def scan_one_message(self, session, mailbox_idx, mbox, msg_mbox_key,
                          wait=False, **kwargs):
         args = [session, mailbox_idx, mbox, msg_mbox_key]
-        task = 'scan:%s/%s' % (mailbox_idx, msg_mbox_key)
+        task = 'scan:{0!s}/{1!s}'.format(mailbox_idx, msg_mbox_key)
         if wait:
             return session.config.scan_worker.do(
                 session, task, lambda: self._real_scan_one(*args, **kwargs))
@@ -844,8 +844,7 @@ class MailIndex(object):
                                                        event=event)
 
         if 'rescan' in session.config.sys.debug:
-            session.ui.debug('Reading message %s/%s'
-                             % (mailbox_idx, msg_mbox_idx))
+            session.ui.debug('Reading message {0!s}/{1!s}'.format(mailbox_idx, msg_mbox_idx))
         try:
             if msg_data:
                 msg_fd = cStringIO.StringIO(msg_data)
@@ -1103,7 +1102,7 @@ class MailIndex(object):
         # Part 1: Figure out parent stuff.
         if in_reply_to:
             if '<' in in_reply_to:
-                irt_ref = '<%s>' % in_reply_to.split('<')[1].split('>')[0]
+                irt_ref = '<{0!s}>'.format(in_reply_to.split('<')[1].split('>')[0])
                 while irt_ref in refs:
                     refs.remove(irt_ref)
                 refs.append(irt_ref)
@@ -1264,7 +1263,7 @@ class MailIndex(object):
         if eid is None:
             eid = len(self.EMAILS)
             self.EMAILS.append('')
-        self.EMAILS[eid] = '%s (%s)' % (email, name or email)
+        self.EMAILS[eid] = '{0!s} ({1!s})'.format(email, name or email)
         self.EMAIL_IDS[email.lower()] = eid
         # FIXME: This needs to get written out...
         return eid
@@ -1359,7 +1358,7 @@ class MailIndex(object):
                         if kw in keywordmap:
                             del keywordmap[kw]
                     if t[0] != '-':
-                        keywordmap[unicode('%s:in' % t[1:])] = msg_idx_list
+                        keywordmap[unicode('{0!s}:in'.format(t[1:]))] = msg_idx_list
 
         return set(keywordmap.keys())
 
@@ -1455,7 +1454,7 @@ class MailIndex(object):
                                  in re.findall(WORD_REGEXP, att.lower())])
                 for kw, ext_list in ATT_EXTS.iteritems():
                     if att.lower().rsplit('.', 1)[-1] in ext_list:
-                        keywords.append('%s:has' % kw)
+                        keywords.append('{0!s}:has'.format(kw))
                 textpart = (textpart or '') + ' ' + att
 
             if textpart:
@@ -1508,16 +1507,16 @@ class MailIndex(object):
                         keywords.extend(kwe(self, msg, 'text/plain', text,
                                             body_info=body_info))
 
-        keywords.append('%s:id' % msg_id)
+        keywords.append('{0!s}:id'.format(msg_id))
         keywords.extend(re.findall(WORD_REGEXP,
                                    self.hdr(msg, 'subject').lower()))
         keywords.extend(re.findall(WORD_REGEXP,
                                    self.hdr(msg, 'from').lower()))
         if mailbox:
-            keywords.append('%s:mailbox' % FormatMbxId(mailbox).lower())
+            keywords.append('{0!s}:mailbox'.format(FormatMbxId(mailbox).lower()))
 
         # This is a signal for the bayesian filters to discriminate by MUA.
-        keywords.append('%s:hp' % HeaderPrint(msg))
+        keywords.append('{0!s}:hp'.format(HeaderPrint(msg)))
 
         is_list = False
         for key in msg.keys():
@@ -1540,9 +1539,9 @@ class MailIndex(object):
                 emails = [e for e in emails if
                           (len(e) < 40) or ('+' not in e and '/' not in e)]
 
-                keywords.extend(['%s:%s' % (t, key_lower) for t in words])
-                keywords.extend(['%s:%s' % (e, key_lower) for e in emails])
-                keywords.extend(['%s:email' % e for e in emails])
+                keywords.extend(['{0!s}:{1!s}'.format(t, key_lower) for t in words])
+                keywords.extend(['{0!s}:{1!s}'.format(e, key_lower) for e in emails])
+                keywords.extend(['{0!s}:email'.format(e) for e in emails])
 
         # Personal mail: not from lists or common robots?
         msg_from = msg.get('from', '').lower()
@@ -1560,7 +1559,7 @@ class MailIndex(object):
 
         for key in EXPECTED_HEADERS:
             if not msg[key]:
-                keywords.append('%s:missing' % key)
+                keywords.append('{0!s}:missing'.format(key))
 
         for extract in _plugins.get_meta_kw_extractors():
             keywords.extend(extract(self, msg_mid, msg, msg_size, msg_ts,
@@ -1603,7 +1602,7 @@ class MailIndex(object):
 
         # Apply the defaults for this mail source / mailbox.
         if apply_tags:
-            keywords |= set(['%s:in' % tid for tid in apply_tags])
+            keywords |= set(['{0!s}:in'.format(tid) for tid in apply_tags])
         if process_new:
             process_new(msg, msg_metadata_kws, msg_ts, keywords, snippet)
         elif incoming:
@@ -1613,7 +1612,7 @@ class MailIndex(object):
                 ProcessNew(session, msg, msg_metadata_kws, msg_ts,
                            keywords, snippet)
             if apply_tags is None:
-                keywords |= set(['%s:in' % tag._key for tag in
+                keywords |= set(['{0!s}:in'.format(tag._key) for tag in
                                  self.config.get_tags(type='inbox')])
 
         for hook in filter_hooks or []:
@@ -1621,7 +1620,7 @@ class MailIndex(object):
                             incoming=incoming)
 
         if 'keywords' in self.config.sys.debug:
-            print 'KEYWORDS: %s' % keywords
+            print 'KEYWORDS: {0!s}'.format(keywords)
 
         for word in keywords:
             if (word.startswith('__') or
@@ -1681,11 +1680,11 @@ class MailIndex(object):
         self.update_msg_tags(msg_idx, msg_info)
 
         if not original_line:
-            dirty_tags = [u'%s:in' % self.config.tags[t].slug for t in
+            dirty_tags = [u'{0!s}:in'.format(self.config.tags[t].slug) for t in
                           self.get_tags(msg_info=msg_info)]
             self.config.command_cache.mark_dirty(
-                [u'mail:all', u'%s:msg' % msg_idx,
-                 u'%s:thread' % int(msg_thr_mid, 36)] + dirty_tags)
+                [u'mail:all', u'{0!s}:msg'.format(msg_idx),
+                 u'{0!s}:thread'.format(int(msg_thr_mid, 36))] + dirty_tags)
             CachedSearchResultSet.DropCaches(msg_idxs=[msg_idx])
             self.MODIFIED.add(msg_idx)
             try:
@@ -1782,9 +1781,9 @@ class MailIndex(object):
                 self.TAGS[tag_id] = eids
         try:
             self.config.command_cache.mark_dirty(
-                [u'mail:all', u'%s:in' % self.config.tags[tag_id].slug] +
-                [u'%s:msg' % e_idx for e_idx in added] +
-                [u'%s:thread' % int(mid, 36) for mid in threads])
+                [u'mail:all', u'{0!s}:in'.format(self.config.tags[tag_id].slug)] +
+                [u'{0!s}:msg'.format(e_idx) for e_idx in added] +
+                [u'{0!s}:thread'.format(int(mid, 36)) for mid in threads])
         except:
             pass
         return added
@@ -1836,9 +1835,9 @@ class MailIndex(object):
                 self.TAGS[tag_id] -= eids
         try:
             self.config.command_cache.mark_dirty(
-                [u'%s:in' % self.config.tags[tag_id].slug] +
-                [u'%s:msg' % e_idx for e_idx in removed] +
-                [u'%s:thread' % int(mid, 36) for mid in threads])
+                [u'{0!s}:in'.format(self.config.tags[tag_id].slug)] +
+                [u'{0!s}:msg'.format(e_idx) for e_idx in removed] +
+                [u'{0!s}:thread'.format(int(mid, 36)) for mid in threads])
         except:
             pass
         return removed
@@ -1850,11 +1849,11 @@ class MailIndex(object):
         if tag:
             tag_id = tag._key
             for subtag in self.config.get_tags(parent=tag_id):
-                results.extend(hits('%s:in' % subtag._key))
+                results.extend(hits('{0!s}:in'.format(subtag._key)))
             if tag.magic_terms and recursion < 5:
                 results.extend(self.search(session, [tag.magic_terms],
                                            recursion=recursion+1).as_set())
-        results.extend(hits('%s:in' % tag_id))
+        results.extend(hits('{0!s}:in'.format(tag_id)))
         return results
 
     def _vfs_hits(self, session, searchterms):
@@ -1914,7 +1913,7 @@ class MailIndex(object):
                     where = searchterms.index(p + 'is:unread')
                     new = session.config.get_tags(type='unread')
                     if new:
-                        searchterms[where] = p + 'in:%s' % new[0].slug
+                        searchterms[where] = p + 'in:{0!s}'.format(new[0].slug)
                 for t in [term for term in searchterms
                           if term.startswith(p + 'tag:')]:
                     where = searchterms.index(t)
@@ -1966,21 +1965,21 @@ class MailIndex(object):
                         emails += [vcl.value for vcl in vc.get_all('email')]
                     for email in set(emails):
                         if email:
-                            rt.extend(hits('%s:%s' % (email,
+                            rt.extend(hits('{0!s}:{1!s}'.format(email,
                                                       term.split(':')[0])))
                 elif term == 'is:encrypted':
                     for status in EncryptionInfo.STATUSES:
                         if status in CryptoInfo.STATUSES:
                             continue
                         rt.extend(self.search_tag(session,
-                                                  'in:mp_enc-%s' % status,
+                                                  'in:mp_enc-{0!s}'.format(status),
                                                   hits, recursion=recursion))
                 elif term == 'is:signed':
                     for status in SignatureInfo.STATUSES:
                         if status in CryptoInfo.STATUSES:
                             continue
                         rt.extend(self.search_tag(session,
-                                                  'in:mp_sig-%s' % status,
+                                                  'in:mp_sig-{0!s}'.format(status),
                                                   hits, recursion=recursion))
                 else:
                     t = term.split(':', 1)
@@ -1988,7 +1987,7 @@ class MailIndex(object):
                     if fnc:
                         rt.extend(fnc(self.config, self, term, hits))
                     else:
-                        rt.extend(hits('%s:%s' % (t[1], t[0])))
+                        rt.extend(hits('{0!s}:{1!s}'.format(t[1], t[0])))
             else:
                 rt.extend(hits(term))
 
@@ -2015,7 +2014,7 @@ class MailIndex(object):
                 ('tags' in self.config) and
                 (not session or 'all' not in order)):
             invisible = self.config.get_tags(flag_hides=True)
-            exclude_terms = ['in:%s' % i._key for i in invisible]
+            exclude_terms = ['in:{0!s}'.format(i._key) for i in invisible]
             for tag in invisible:
                 tid = tag._key
                 for p in ('in:%s', '+in:%s', '-in:%s'):
@@ -2025,7 +2024,7 @@ class MailIndex(object):
                         exclude_terms = []
             if len(exclude_terms) > 1:
                 exclude_terms = ([exclude_terms[0]] +
-                                 ['+%s' % e for e in exclude_terms[1:]])
+                                 ['+{0!s}'.format(e) for e in exclude_terms[1:]])
             # Recursing to pull the excluded terms from cache as well
             exclude = self.search(session, exclude_terms).as_set()
 
@@ -2088,7 +2087,7 @@ class MailIndex(object):
                 results.sort()
             elif how.endswith('random'):
                 now = time.time()
-                results.sort(key=lambda k: sha1b64('%s%s' % (now, k)))
+                results.sort(key=lambda k: sha1b64('{0!s}{1!s}'.format(now, k)))
             else:
                 did_sort = False
                 for order in self.INDEX_SORT:
@@ -2171,6 +2170,6 @@ if __name__ == '__main__':
     import sys
     results = doctest.testmod(optionflags=doctest.ELLIPSIS,
                               extraglobs={})
-    print '%s' % (results, )
+    print '{0!s}'.format(results )
     if results.failed:
         sys.exit(1)

--- a/mailpile/security.py
+++ b/mailpile/security.py
@@ -125,7 +125,7 @@ def secure_urlget(session, url, data=None, timeout=30, anonymous=False):
         raise IOError("Web content is disabled by policy")
 
     if url[:5].lower() not in ('http:', 'https'):
-        raise IOError('Non-HTTP URLs are forbidden: %s' % url)
+        raise IOError('Non-HTTP URLs are forbidden: {0!s}'.format(url))
 
     if url.startswith('https:'):
         conn_need, conn_reject = [ConnBroker.OUTGOING_HTTPS], []
@@ -162,9 +162,9 @@ def make_csrf_token(req, session_id, ts=None):
     Generate a hashed token from the current timestamp, session ID and
     the server secret, to avoid CSRF attacks.
     """
-    ts = '%x' % (ts if (ts is not None) else time.time())
+    ts = '{0:x}'.format((ts if (ts is not None) else time.time()))
     payload = [req.server.secret, session_id, ts]
-    return '%s-%s' % (ts, b64w(sha512b64('-'.join(payload))))
+    return '{0!s}-{1!s}'.format(ts, b64w(sha512b64('-'.join(payload))))
 
 
 def valid_csrf_token(req, session_id, csrf_token):

--- a/mailpile/smtp_client.py
+++ b/mailpile/smtp_client.py
@@ -72,7 +72,7 @@ def SMTorP_HashCash(rcpt, msg, callback1k=None):
         if callback1k:
             callback1k(*args, **kwargs)
 
-    return '%s##%s' % (rcpt, sha512_512kCollide(challenge, int(bits),
+    return '{0!s}##{1!s}'.format(rcpt, sha512_512kCollide(challenge, int(bits),
                                                 callback1k=cb))
 
 
@@ -119,7 +119,7 @@ def _RouteTuples(session, from_to_msg_ev_tuples, test_route=None):
                     route.update(session.config.get_route(frm, [recipient]))
 
                 # Group together recipients that use the same route
-                rid = '/'.join(sorted(['%s' % (k, )
+                rid = '/'.join(sorted(['{0!s}'.format(k )
                                        for k in route.iteritems()]))
                 routes[rid] = route
                 rcpts[rid] = rcpts.get(rid, [])
@@ -170,8 +170,8 @@ def SendMail(session, msg_mid, from_to_msg_ev_tuples,
     def smtp_do_or_die(msg, events, method, *args, **kwargs):
         rc, msg = method(*args, **kwargs)
         if rc != 250:
-            fail(msg + ' (%s %s)' % (rc, msg), events,
-                 details={'smtp_error': '%s: %s' % (rc, msg)})
+            fail(msg + ' ({0!s} {1!s})'.format(rc, msg), events,
+                 details={'smtp_error': '{0!s}: {1!s}'.format(rc, msg)})
 
     # Do the actual delivering...
     for frm, route, to, msg, events in routes:

--- a/mailpile/tests/data/pgp-data/buildexamples.py
+++ b/mailpile/tests/data/pgp-data/buildexamples.py
@@ -29,7 +29,7 @@ def genExamples():
 	contents = open("sources/" + source, "r").read()
 	language, charset = source.split(".")
         for process in getProcesses():
-            print "Creating %s mail with %s encoding and %s PGP" % (language,
+            print "Creating {0!s} mail with {1!s} encoding and {2!s} PGP".format(language,
                   charset, process)
             string = runPGP(contents, process)
             e = email.message_from_string(string)

--- a/mailpile/tests/gui/__init__.py
+++ b/mailpile/tests/gui/__init__.py
@@ -96,7 +96,7 @@ class SeleniumScreenshotOnExceptionAspecter(type):
                 results = method(*args, **kw)
             except:
                 test_self = args[0]
-                filename = '%s_screenshot.png' % method.__name__
+                filename = '{0!s}_screenshot.png'.format(method.__name__)
                 test_self.take_screenshot(filename)
                 raise
 
@@ -151,7 +151,7 @@ class MailpileSeleniumTest(MailPileUnittest):
 
     @classmethod
     def _get_mailpile_url(cls):
-        return 'http://%s:%s/%s' % cls._get_mailpile_sspec()
+        return 'http://{0!s}:{1!s}/{2!s}'.format(*cls._get_mailpile_sspec())
 
     @classmethod
     def _start_web_server(cls):
@@ -202,7 +202,7 @@ class MailpileSeleniumTest(MailPileUnittest):
         MailpileSeleniumTest._stop_selenium_driver()
 
     def go_to_mailpile_home(self):
-        self.driver.get('%s/in/inbox' % self._get_mailpile_url())
+        self.driver.get('{0!s}/in/inbox'.format(self._get_mailpile_url()))
 
     def take_screenshot(self, filename):
         try:
@@ -216,7 +216,7 @@ class MailpileSeleniumTest(MailPileUnittest):
 
     def navigate_to(self, name):
         contacts = self.find_element_by_xpath(
-            '//a[@alt="%s"]/span' % name)
+            '//a[@alt="{0!s}"]/span'.format(name))
         self.assertTrue(contacts.is_displayed())
         contacts.click()
 
@@ -253,7 +253,7 @@ class MailpileSeleniumTest(MailPileUnittest):
         return self.driver.find_element_by_id(id)
 
     def find_element_containing_text(self, text):
-        return self.driver.find_element_by_xpath("//*[contains(.,'%s')]" % text)
+        return self.driver.find_element_by_xpath("//*[contains(.,'{0!s}')]".format(text))
 
     def find_element_by_xpath(self, xpath):
         return self.driver.find_element_by_xpath(xpath)

--- a/mailpile/tests/test_command.py
+++ b/mailpile/tests/test_command.py
@@ -75,7 +75,7 @@ class TestCommands(MailPileUnittest):
         mid = self.mp.search('from:ohcheeou').result['data']['metadata']\
                                              .values()[0]['mid']
         # Just checks it does not crash
-        res = self.mp.reply('ephemeral', '=%s' % mid)
+        res = self.mp.reply('ephemeral', '={0!s}'.format(mid))
         self.assertEqual(res.status, 'success')
         self.assertEqual(res.result['data']['metadata'].values()[0]['subject'],
                          'Re:')
@@ -84,7 +84,7 @@ class TestCommands(MailPileUnittest):
         # Subject: Verb. Target. Outcome.'
         mid = self.mp.search('subject:Verb').result['data']['metadata']\
                                             .values()[0]['mid']
-        res = self.mp.reply('ephemeral', '=%s' % mid)
+        res = self.mp.reply('ephemeral', '={0!s}'.format(mid))
         self.assertEqual(res.result['data']['metadata'].values()[0]['subject'],
                          'Re: Verb. Target. Outcome.')
 
@@ -92,7 +92,7 @@ class TestCommands(MailPileUnittest):
         # Subject: Re: Here's $1
         mid = self.mp.search('subject:Here').result['data']['metadata']\
                                             .values()[0]['mid']
-        res = self.mp.reply('ephemeral', '=%s' % mid)
+        res = self.mp.reply('ephemeral', '={0!s}'.format(mid))
         self.assertEqual(res.result['data']['metadata'].values()[0]['subject'],
                          "Re: Here's $1")
 
@@ -100,7 +100,7 @@ class TestCommands(MailPileUnittest):
         # Subject: Fw: About shrubberies
         mid = self.mp.search('shrubberies').result['data']['metadata']\
                                            .values()[0]['mid']
-        res = self.mp.reply('ephemeral', '=%s' % mid)
+        res = self.mp.reply('ephemeral', '={0!s}'.format(mid))
         self.assertEqual(res.result['data']['metadata'].values()[0]['subject'],
                          "Re: Fw: About shrubberies")
 
@@ -108,7 +108,7 @@ class TestCommands(MailPileUnittest):
         # Subject: Re: Here's $1
         mid = self.mp.search('subject:Here').result['data']['metadata']\
                                             .values()[0]['mid']
-        res = self.mp.forward('ephemeral', '=%s' % mid)
+        res = self.mp.forward('ephemeral', '={0!s}'.format(mid))
         self.assertEqual(res.result['data']['metadata'].values()[0]['subject'],
                          "Fwd: Re: Here's $1")
 
@@ -116,7 +116,7 @@ class TestCommands(MailPileUnittest):
         # Subject: Fw: A question shrubberies
         mid = self.mp.search('shrubberies').result['data']['metadata']\
                                            .values()[0]['mid']
-        res = self.mp.forward('ephemeral', '=%s' % mid)
+        res = self.mp.forward('ephemeral', '={0!s}'.format(mid))
         self.assertEqual(res.result['data']['metadata'].values()[0]['subject'],
                          "Fw: About shrubberies")
 

--- a/mailpile/tests/test_crypto_policy.py
+++ b/mailpile/tests/test_crypto_policy.py
@@ -29,7 +29,7 @@ class UpdateCryptoPolicyForUserTest(CryptoPolicyBaseTest):
         for policy in ['default', 'none', 'sign', 'sign-encrypt',
                        'encrypt', 'best-effort']:
             r = self.mp.crypto_policy_set('test@test.local', policy)
-            print '%s' % r.as_dict()
+            print '{0!s}'.format(r.as_dict())
             self.assertEqual('success', r.as_dict()['status'])
 
         for policy in ['anything', 'else']:

--- a/mailpile/tests/test_keylookup.py
+++ b/mailpile/tests/test_keylookup.py
@@ -22,7 +22,7 @@ fpr = "08A650B8E2CBC1B02297915DC65626EED13C70DA"
 url = "https://mailpile.is/gpgkey.gpg"
 DNSPKA_MOCK_RETURN = [{
     'typename': 'TXT', 'name': 'test._pka.mailpile.is',
-    'data': ['v=pka1;fpr=%s;uri=%s' % (fpr, url)],
+    'data': ['v=pka1;fpr={0!s};uri={1!s}'.format(fpr, url)],
 }]
 
 

--- a/mailpile/tests/test_performance.py
+++ b/mailpile/tests/test_performance.py
@@ -8,7 +8,7 @@ def checkSearch(postinglist_kb, query):
     class TestSearch(object):
         def __init__(self):
             self.mp = get_shared_mailpile()[0]
-            self.mp.set("sys.postinglist_kb=%s" % postinglist_kb)
+            self.mp.set("sys.postinglist_kb={0!s}".format(postinglist_kb))
             self.mp.set("prefs.num_results=50")
             self.mp.set("prefs.default_order=rev-date")
             results = self.mp.search(*query)

--- a/mailpile/tests/test_plugin.py
+++ b/mailpile/tests/test_plugin.py
@@ -25,7 +25,7 @@ class PluginTest(MailPileUnittest):
     def test_code_files_are_loaded_in_order(self):
         # given
         def create_python_file_add_stmt(number, filename):
-            self._create_code_file('from mailpile.plugins.order import add\nadd(%d)' % number, path.join(order_plugin_path, filename))
+            self._create_code_file('from mailpile.plugins.order import add\nadd({0:d})'.format(number), path.join(order_plugin_path, filename))
 
         order_plugin_path = path.join(self.plugin_dir, 'order')
         os.mkdir(order_plugin_path)

--- a/mailpile/tests/test_search.py
+++ b/mailpile/tests/test_search.py
@@ -13,9 +13,9 @@ def checkSearch(query, expected_count=1):
                 assert_equal(results.result['stats']['count'], expected_count)
                 assert_less(float(results.as_dict()["elapsed"]), 0.2)
             except:
-                print 'BAD RESULT:\n%s' % results.as_text()
+                print 'BAD RESULT:\n{0!s}'.format(results.as_text())
                 raise
-    TestSearch.description = "Searching for %s" % str(query)
+    TestSearch.description = "Searching for {0!s}".format(str(query))
     return TestSearch
 
 

--- a/mailpile/ui.py
+++ b/mailpile/ui.py
@@ -76,13 +76,13 @@ class NoColors:
         return 79
 
     def color(self, text, color='', weight='', readline=False):
-        return '%s%s%s' % ((self.FORMAT_READLINE if readline else self.FORMAT)
+        return '{0!s}{1!s}{2!s}'.format((self.FORMAT_READLINE if readline else self.FORMAT)
                            % (color, weight), text, self.RESET)
 
     def replace_line(self, text, chars=None):
         pad = ' ' * max(0, min(self.max_width(),
                                self.max_width()-(chars or len(unicode(text)))))
-        return '%s%s\r' % (text, pad)
+        return '{0!s}{1!s}\r'.format(text, pad)
 
     def add_line_below(self):
         pass
@@ -124,7 +124,7 @@ class ANSIColors(NoColors):
         self.check_max_width()
 
     def replace_line(self, text, chars=None):
-        return '%s%s%s\r%s' % (self.CURSOR_SAVE,
+        return '{0!s}{1!s}{2!s}\r{3!s}'.format(self.CURSOR_SAVE,
                                self.CLEAR_LINE, text,
                                self.CURSOR_RESTORE)
 
@@ -242,7 +242,7 @@ class UserInteraction:
 
     def _display_log(self, text, level=LOG_URGENT):
         if not text.startswith(self.log_prefix):
-            text = '%slog(%s): %s' % (self.log_prefix, level, text)
+            text = '{0!s}log({1!s}): {2!s}'.format(self.log_prefix, level, text)
         if self.log_parent is not None:
             self.log_parent.log(level, text)
         else:
@@ -251,7 +251,7 @@ class UserInteraction:
     def _debug_log(self, text, level):
         if text and 'log' in self.config.sys.debug:
             if not text.startswith(self.log_prefix):
-                text = '%slog(%s): %s' % (self.log_prefix, level, text)
+                text = '{0!s}log({1!s}): {2!s}'.format(self.log_prefix, level, text)
             if self.log_parent is not None:
                 return self.log_parent.log(level, text)
             else:
@@ -319,7 +319,7 @@ class UserInteraction:
                     if details:
                         for i in range(0, len(self.times)-1):
                             e = t[i+1][0] - t[i][0]
-                            self.debug(' -> %.3fs (%s)' % (e, t[i][1]))
+                            self.debug(' -> {0:.3f}s ({1!s})'.format(e, t[i][1]))
                 except IndexError:
                     self.notify(_('Elapsed: %.3fs') % elapsed)
             return elapsed
@@ -356,7 +356,7 @@ class UserInteraction:
         self.push_marks(cmd)
         self.mark(('%s(%s)'
                    ) % (cmd, ', '.join((args or tuple()) +
-                                       ('%s' % kwargs, ))))
+                                       ('{0!s}'.format(kwargs), ))))
 
     def finish_command(self, cmd):
         self.pop_marks(name=cmd)
@@ -409,7 +409,7 @@ class UserInteraction:
         except (TypeError, ValueError, KeyError, IndexError,
                 UnicodeDecodeError):
             traceback.print_exc()
-            return '[%s]' % _('Internal Error')
+            return '[{0!s}]'.format(_('Internal Error'))
 
     # Creating output files
     DEFAULT_DATA_NAME_FMT = '%(msg_mid)s.%(count)s_%(att_name)s.%(att_ext)s'
@@ -435,7 +435,7 @@ class UserInteraction:
     def _make_data_attributes(self, attributes={}):
         attrs = self.DEFAULT_DATA_ATTRS.copy()
         attrs.update(attributes)
-        attrs['rand'] = '%4.4x' % random.randint(0, 0xffff)
+        attrs['rand'] = '{0:4.4x}'.format(random.randint(0, 0xffff))
         if attrs['att_ext'] == self.DEFAULT_DATA_ATTRS['att_ext']:
             if attrs['mimetype'] in self.DEFAULT_DATA_EXTS:
                 attrs['att_ext'] = self.DEFAULT_DATA_EXTS[attrs['mimetype']]
@@ -490,9 +490,9 @@ class UserInteraction:
         for kw in ('error', 'details', 'traceback', 'source', 'data'):
             value = error_info.get(kw, '')
             if isinstance(value, dict):
-                ei[kw] = escape_html('%.8196s' % self.render_json(value))
+                ei[kw] = escape_html('{0:.8196!s}'.format(self.render_json(value)))
             else:
-                ei[kw] = escape_html('%.2048s' % value).replace('\n', '<br>')
+                ei[kw] = escape_html('{0:.2048!s}'.format(value)).replace('\n', '<br>')
         return emsg % ei
 
     def render_web(self, cfg, tpl_names, data):
@@ -523,15 +523,14 @@ class UserInteraction:
             tpl_esc_names = [escape_html(tn) for tn in tpl_names]
             return self._render_error(cfg, {
                 'error': _('Template not found'),
-                'details': 'In %s:\n%s' % (e.name, e.message),
+                'details': 'In {0!s}:\n{1!s}'.format(e.name, e.message),
                 'data': alldata
             })
         except (TemplateError, TemplateSyntaxError,
                 TemplateAssertionError,), e:
             return self._render_error(cfg, {
                 'error': _('Template error'),
-                'details': ('In %s (%s), line %s:\n%s'
-                            % (e.name, e.filename, e.lineno, e.message)),
+                'details': ('In {0!s} ({1!s}), line {2!s}:\n{3!s}'.format(e.name, e.filename, e.lineno, e.message)),
                 'source': e.source,
                 'traceback': traceback.format_exc(),
                 'data': alldata
@@ -547,7 +546,7 @@ class UserInteraction:
                 raise NotEditableError(_('Message %s is not editable')
                                        % e.msg_mid())
 
-        sep = '%s(%8.8x%3.3x)-\n' % ('-' * 68, time.time(),
+        sep = '{0!s}({1:8.8x}{2:3.3x})-\n'.format('-' * 68, time.time(),
                                      random.randint(0, 0xfff))
         edit_this = ('\n'+sep).join([e.get_editing_string() for e in emails])
 
@@ -557,7 +556,7 @@ class UserInteraction:
         with self.term:
             try:
                 self.block()
-                os.system('%s %s' % (os.getenv('VISUAL', default='vi'),
+                os.system('{0!s} {1!s}'.format(os.getenv('VISUAL', default='vi'),
                                      tf.name))
             finally:
                 self.unblock()
@@ -609,12 +608,12 @@ class HttpUserInteraction(UserInteraction):
 
     def _render_text_responses(self, config):
         if config.sys.debug:
-            return '%s\n%s' % (
+            return '{0!s}\n{1!s}'.format(
                 '\n'.join([l[1] for l in self.logged]),
-                ('\n%s\n' % ('=' * 79)).join(r for t, r in self.results)
+                ('\n{0!s}\n'.format(('=' * 79))).join(r for t, r in self.results)
             )
         else:
-            return ('\n%s\n' % ('=' * 79)).join(r for t, r in self.results)
+            return ('\n{0!s}\n'.format(('=' * 79))).join(r for t, r in self.results)
 
     def _ttype_to_mimetype(self, ttype, result):
         return ({
@@ -635,7 +634,7 @@ class HttpUserInteraction(UserInteraction):
             if len(self.results) == 1:
                 data = self.results[0][1]
             else:
-                data = '[%s]' % ','.join(r for t, r in self.results)
+                data = '[{0!s}]'.format(','.join(r for t, r in self.results))
             return ('application/json', data)
         else:
             if len(self.results) == 1:
@@ -701,7 +700,7 @@ class RawHttpResponder:
         if disposition and filename:
             encfilename = urllib.quote(filename.encode("utf-8"))
             headers.append(('Content-Disposition',
-                            '%s; filename*=UTF-8\'\'%s' % (disposition,
+                            '{0!s}; filename*=UTF-8\'\'{1!s}'.format(disposition,
                                                            encfilename)))
         elif disposition:
             headers.append(('Content-Disposition', disposition))
@@ -763,7 +762,7 @@ class Session(object):
                 sid = self.config.search_history.add(self.searched,
                                                      self.results,
                                                      self.order)
-                self.context = 'search:%s' % sid
+                self.context = 'search:{0!s}'.format(sid)
         return self.context
 
     def load_context(self, context):

--- a/mailpile/urlmap.py
+++ b/mailpile/urlmap.py
@@ -103,13 +103,13 @@ class UrlMap:
                      if ((method and name == c.SYNOPSIS[2]) or
                          (not method and name == c.SYNOPSIS[1]))]
             if len(match) != 1:
-                raise UsageError('Unknown command: %s' % name)
+                raise UsageError('Unknown command: {0!s}'.format(name))
         except ValueError, e:
             raise UsageError(str(e))
         command = match[0]
 
         if method and (method not in command.HTTP_CALLABLE):
-            raise BadMethodError('Invalid method (%s): %s' % (method, name))
+            raise BadMethodError('Invalid method ({0!s}): {1!s}'.format(method, name))
 
         # FIXME: Move this somewhere smarter
         SPECIAL_VARS = ('csrf', 'arg', 'context')
@@ -126,7 +126,7 @@ class UrlMap:
                 if (var not in command.HTTP_QUERY_VARS and
                         (var not in SPECIAL_VARS) and
                         (not [v for v in prefixes if var.startswith(v)])):
-                    raise BadDataError('Bad variable (%s): %s' % (var, name))
+                    raise BadDataError('Bad variable ({0!s}): {1!s}'.format(var, name))
                 else:
                     copy_q.append(var)
 
@@ -137,7 +137,7 @@ class UrlMap:
                         (var not in command.HTTP_POST_VARS) and
                         (var not in SPECIAL_VARS) and
                         (not [v for v in prefixes if var.startswith(v)])):
-                    raise BadDataError('Bad variable (%s): %s' % (var, name))
+                    raise BadDataError('Bad variable ({0!s}): {1!s}'.format(var, name))
                 else:
                     copy_p.append(var)
 
@@ -149,7 +149,7 @@ class UrlMap:
                 var = var.replace('[]', '')
                 if ((query_data and var in query_data) or
                         (post_data and var in post_data)):
-                    raise BadDataError('Bad variable (%s): %s' % (var, name))
+                    raise BadDataError('Bad variable ({0!s}): {1!s}'.format(var, name))
 
             copy_vars = (((query_data or {}).keys(), query_data),
                          ((post_data or {}).keys(), post_data),
@@ -220,12 +220,12 @@ class UrlMap:
                 for suffix in self.OUTPUT_SUFFIXES:
                     if fn.endswith(suffix) or suffix == ('.' + fn):
                         return self._command('output', [om], method=False)
-            raise UsageError('Invalid output format: %s' % om)
+            raise UsageError('Invalid output format: {0!s}'.format(om))
         return self._command('output', [fmt], method=False)
 
     def _map_root(self, request, path_parts, query_data, post_data):
         """Redirects to /profiles/ for now.  (FIXME)"""
-        destination = '%s/profiles/' % self.config.sys.http_path
+        destination = '{0!s}/profiles/'.format(self.config.sys.http_path)
         return [UrlRedirect(self.session, 'redirect', arg=[destination])]
 
     def _map_tag(self, request, path_parts, query_data, post_data):
@@ -250,7 +250,7 @@ class UrlMap:
         tag_slug = '/'.join([p for p in path_parts[1:] if p])
         tag = self.config.get_tag(tag_slug)
         tag_search = [term for term in (tag.search_terms % tag).split()
-                      if term] if tag is not None else ["in:%s" % tag_slug]
+                      if term] if tag is not None else ["in:{0!s}".format(tag_slug)]
         if tag is not None and tag.search_order and 'order' not in query_data:
             query_data['order'] = [tag.search_order]
 
@@ -320,7 +320,7 @@ class UrlMap:
                 pass
             except BadMethodError:
                 break
-        raise UsageError('Not available for %s: %s' % (method,
+        raise UsageError('Not available for {0!s}: {1!s}'.format(method,
                                                        '/'.join(path_parts)))
 
     MAP_API = 'api'
@@ -383,8 +383,8 @@ class UrlMap:
         else:
             sid = user_session = None
 
-        is_async = path.startswith('/%s/' % self.MAP_ASYNC_API)
-        is_api = path.startswith('/%s/' % self.MAP_API)
+        is_async = path.startswith('/{0!s}/'.format(self.MAP_ASYNC_API))
+        is_api = path.startswith('/{0!s}/'.format(self.MAP_API))
 
         if authenticate:
             def auth(commands, user_session):
@@ -422,7 +422,7 @@ class UrlMap:
         if is_api or is_async:
             path_parts = path.split('/')
             if int(path_parts[2]) not in self.API_VERSIONS:
-                raise UsageError('Unknown API level: %s' % path_parts[2])
+                raise UsageError('Unknown API level: {0!s}'.format(path_parts[2]))
             return auth(self._map_api_command(method, path_parts[3:],
                                               query_data, post_data,
                                               fmt='json', async=is_async),
@@ -449,21 +449,21 @@ class UrlMap:
 
     def _url(self, url, output='', qs=''):
         if output and '.' not in output:
-            output = 'as.%s' % output
+            output = 'as.{0!s}'.format(output)
         return ''.join([self.config.sys.http_path,
                         url, output, qs and '?' or '', qs])
 
     def url_thread(self, message_id, output=''):
         """Map a message to it's short-hand thread URL."""
-        return self._url('/thread/=%s/' % message_id, output)
+        return self._url('/thread/={0!s}/'.format(message_id), output)
 
     def url_source(self, message_id, output=''):
         """Map a message to it's raw message source URL."""
-        return self._url('/message/raw/=%s/as.text' % message_id, output)
+        return self._url('/message/raw/={0!s}/as.text'.format(message_id), output)
 
     def url_edit(self, message_id, output=''):
         """Map a message to it's short-hand editing URL."""
-        return self._url('/message/draft/=%s/' % message_id, output)
+        return self._url('/message/draft/={0!s}/'.format(message_id), output)
 
     def redirect_to_auth_or_setup(self, method, path, query_data, setup=True):
         """Redirect to the /auth/ or a /setup/* endpoint"""
@@ -480,9 +480,9 @@ class UrlMap:
             nxt = Setup.Next(self.session.config, mailpile.auth.Authenticate)
             if nxt.HTTP_AUTH_REQUIRED is True:
                 nxt = mailpile.auth.Authenticate
-            path = '/%s/' % nxt.SYNOPSIS[2]
+            path = '/{0!s}/'.format(nxt.SYNOPSIS[2])
         else:
-            path = '/%s/' % mailpile.auth.Authenticate.SYNOPSIS[2]
+            path = '/{0!s}/'.format(mailpile.auth.Authenticate.SYNOPSIS[2])
 
         raise UrlRedirectException(self._url(path, qs=urlencode(qd)))
 
@@ -516,8 +516,8 @@ class UrlMap:
                    if t.slug == tag_id.lower()]
             tag = tag and tag[0]
         if tag:
-            return self._url('/in/%s/' % tag.slug, output)
-        raise ValueError('Unknown tag: %s' % tag_id)
+            return self._url('/in/{0!s}/'.format(tag.slug), output)
+        raise ValueError('Unknown tag: {0!s}'.format(tag_id))
 
     def url_sent(self, output=''):
         """Return the URL of the Sent tag"""
@@ -555,16 +555,16 @@ class UrlMap:
 
     def canonical_url(self, cls):
         """Return the full versioned URL for a command"""
-        return '/api/%s/%s/' % (cls.API_VERSION or self.API_VERSIONS[-1],
+        return '/api/{0!s}/{1!s}/'.format(cls.API_VERSION or self.API_VERSIONS[-1],
                                 cls.SYNOPSIS[2])
 
     def ui_url(self, cls):
         """Return the full user-facing URL for a command"""
-        return '/%s/' % cls.SYNOPSIS[2]
+        return '/{0!s}/'.format(cls.SYNOPSIS[2])
 
     def context_url(self, cls):
         """Return the UI context URL for a command"""
-        return '/%s/' % (cls.UI_CONTEXT or cls.SYNOPSIS[2])
+        return '/{0!s}/'.format((cls.UI_CONTEXT or cls.SYNOPSIS[2]))
 
     def map_as_markdown(self, prefix=None):
         """Describe the current URL map as markdown"""
@@ -577,21 +577,21 @@ class UrlMap:
                            for c in self._api_commands(method, strict=True)])
 
         text.extend([
-            '# Mailpile URL map (autogenerated by %s)' % __file__,
+            '# Mailpile URL map (autogenerated by {0!s})'.format(__file__),
             '',
             '\n'.join([line.strip() for line
                        in UrlMap.__doc__.strip().splitlines()[2:]]),
             '',
-            '## The API paths (version=%s, JSON output)' % api_version,
+            '## The API paths (version={0!s}, JSON output)'.format(api_version),
             '',
         ])
-        api = '/api/%s' % api_version
+        api = '/api/{0!s}'.format(api_version)
         for method in ('GET', 'POST', 'UPDATE', 'DELETE'):
             commands = [c for c in cmds(method)
                         if not prefix or (c[0] and c[0].startswith(prefix))]
             if commands:
                 text.extend([
-                    '### %s%s' % (method, method == 'GET' and
+                    '### {0!s}{1!s}'.format(method, method == 'GET' and
                                   ' (also accept POST)' or ''),
                     '',
                 ])
@@ -605,21 +605,21 @@ class UrlMap:
                 padding = ' ' * (18 - len(command[0]))
                 newline = '\n' + ' ' * (len(api) + len(command[0]) + 6)
                 if query_vars:
-                    qs = '?' + '&'.join(['%s=[%s]' % (v, query_vars[v])
+                    qs = '?' + '&'.join(['{0!s}=[{1!s}]'.format(v, query_vars[v])
                                          for v in query_vars])
                 else:
                     qs = ''
                 if qs:
-                    qs = '%s%s' % (padding, qs)
+                    qs = '{0!s}{1!s}'.format(padding, qs)
                 if pos_args:
-                    pos_args = '%s%s/' % (padding, pos_args)
+                    pos_args = '{0!s}{1!s}/'.format(padding, pos_args)
                     if qs:
                         qs = newline + qs
-                text.append('    %s%s%s' % (url, pos_args, qs))
+                text.append('    {0!s}{1!s}{2!s}'.format(url, pos_args, qs))
                 if cls.HTTP_POST_VARS:
-                    ps = '&'.join(['%s=[%s]' % (v, cls.HTTP_POST_VARS[v])
+                    ps = '&'.join(['{0!s}=[{1!s}]'.format(v, cls.HTTP_POST_VARS[v])
                                    for v in cls.HTTP_POST_VARS])
-                    text.append('    ... POST only: %s' % ps)
+                    text.append('    ... POST only: {0!s}'.format(ps))
             text.append('')
 
         if not prefix:
@@ -630,8 +630,8 @@ class UrlMap:
             ])
             for path in sorted(self.MAP_PATHS.keys()):
                 doc = self.MAP_PATHS[path].__doc__.strip().split('\n')[0]
-                path = ('/%s/' % path).replace('//', '/')
-                text.append('    %s %s %s' % (path, ' ' * (10 - len(path)), doc))
+                path = ('/{0!s}/'.format(path)).replace('//', '/')
+                text.append('    {0!s} {1!s} {2!s}'.format(path, ' ' * (10 - len(path)), doc))
 
         text.extend([
             '',
@@ -643,7 +643,7 @@ class UrlMap:
         for command in sorted(list(set(cmds('GET') + cmds('POST')))):
             if prefix and not command[0].startswith(prefix):
                 continue
-            text.append('    /%s/' % (command[0], ))
+            text.append('    /{0!s}/'.format(command[0] ))
         text.append('')
         return '\n'.join(text)
 
@@ -696,7 +696,7 @@ class HelpUrlMap(Command):
             except:
                 import traceback
                 print traceback.format_exc()
-                html = '<pre>%s</pre>' % escape_html(self.result['urlmap'])
+                html = '<pre>{0!s}</pre>'.format(escape_html(self.result['urlmap']))
             self.result['markdown'] = html
             return Command.CommandResult.as_html(self, *args, **kwargs)
 
@@ -738,7 +738,7 @@ else:
         results = doctest.testmod(optionflags=doctest.ELLIPSIS,
                                   extraglobs={'urlmap': urlmap,
                                               'request': None})
-        print '%s' % (results, )
+        print '{0!s}'.format(results )
         if results.failed:
             sys.exit(1)
     else:

--- a/mailpile/util.py
+++ b/mailpile/util.py
@@ -141,9 +141,9 @@ UNI_BOX_FLIP = dict(UNI_BOX_FLIPS + [(b, a) for a, b in UNI_BOX_FLIPS])
 
 def WhereAmI(start=1):
     stack = inspect.stack()
-    return '%s' % '->'.join(
-        ['%s:%s' % ('/'.join(stack[i][1].split('/')[-2:]), stack[i][2])
-         for i in reversed(range(start, len(stack)-1))])
+    return '{0!s}'.format('->'.join(
+        ['{0!s}:{1!s}'.format('/'.join(stack[i][1].split('/')[-2:]), stack[i][2])
+         for i in reversed(range(start, len(stack)-1))]))
 
 
 def _TracedLock(what, *a, **kw):
@@ -152,13 +152,13 @@ def _TracedLock(what, *a, **kw):
     class Wrapper:
         def acquire(self, *args, **kwargs):
             if self.locked():
-                print '==!== Waiting for %s at %s' % (str(lock), WhereAmI(2))
+                print '==!== Waiting for {0!s} at {1!s}'.format(str(lock), WhereAmI(2))
             return lock.acquire(*args, **kwargs)
         def release(self, *args, **kwargs):
             return lock.release(*args, **kwargs)
         def __enter__(self, *args, **kwargs):
             if self.locked():
-                print '==!== Waiting for %s at %s' % (str(lock), WhereAmI(2))
+                print '==!== Waiting for {0!s} at {1!s}'.format(str(lock), WhereAmI(2))
             return lock.__enter__(*args, **kwargs)
         def __exit__(self, *args, **kwargs):
             return lock.__exit__(*args, **kwargs)
@@ -217,7 +217,7 @@ class AccessError(Exception):
 class UrlRedirectException(Exception):
     """An exception indicating we need to redirecting to another URL."""
     def __init__(self, url):
-        Exception.__init__(self, 'Should redirect to: %s' % url)
+        Exception.__init__(self, 'Should redirect to: {0!s}'.format(url))
         self.url = url
 
 
@@ -464,7 +464,7 @@ def randomish_uid():
         global RID_COUNTER
         RID_COUNTER += 1
         RID_COUNTER %= 0x1000
-        return '%3.3x%7.7x%x' % (random.randint(0, 0xfff),
+        return '{0:3.3x}{1:7.7x}{2:x}'.format(random.randint(0, 0xfff),
                                  time.time() // 16,
                                  RID_COUNTER)
 
@@ -479,8 +479,8 @@ def okay_random(length, *seeds):
     while len(secret) < length:
         # Generate unpredictable bytes from the base64 alphabet
         secret += sha512b64(os.urandom(128 + length * 2),
-                            '%s' % time.time(),
-                            '%x' % random.randint(0, 0xffffffff),
+                            '{0!s}'.format(time.time()),
+                            '{0:x}'.format(random.randint(0, 0xffffffff)),
                             *seeds)
         # Strip confusing characters and truncate
         secret = CleanText(secret, banned=CleanText.NONALNUM + 'O01l\n \t'
@@ -502,7 +502,7 @@ def split_secret(secret, recipients, pad_to=24):
         for j in range(0, recipients-1):
             c ^= parts[j][i]
         last.append(c & 0xff)
-    return [':'.join(['%2.2x' % x for x in p]) for p in parts]
+    return [':'.join(['{0:2.2x}'.format(x) for x in p]) for p in parts]
 
 
 def merge_secret(parts):
@@ -650,7 +650,7 @@ def friendly_number(number, base=1000, decimals=0, suffix='',
         number /= base
         count += 1
     if decimals:
-        fmt = '%%.%df%%s%%s' % decimals
+        fmt = '%.{0:d}f%s%s'.format(decimals)
     else:
         number = round(number)
         fmt = '%d%s%s'
@@ -719,13 +719,13 @@ def backup_file(filename, backups=5, min_age_delta=0):
             return
 
         for ver in reversed(range(1, backups)):
-            bf = '%s.%d' % (filename, ver)
+            bf = '{0!s}.{1:d}'.format(filename, ver)
             if os.path.exists(bf):
-                nbf = '%s.%d' % (filename, ver+1)
+                nbf = '{0!s}.{1:d}'.format(filename, ver+1)
                 if os.path.exists(nbf):
                     os.remove(nbf)
                 os.rename(bf, nbf)
-        os.rename(filename, '%s.1' % filename)
+        os.rename(filename, '{0!s}.1'.format(filename))
 
 
 def json_helper(obj):
@@ -916,7 +916,7 @@ def HideBinary(text):
         text.decode('utf-8')
         return text
     except UnicodeDecodeError:
-        return '[BINARY DATA, %d BYTES]' % len(text)
+        return '[BINARY DATA, {0:d} BYTES]'.format(len(text))
 
 
 class TimedOut(IOError):
@@ -934,7 +934,7 @@ class RunTimedThread(threading.Thread):
         self.start()
         self.join(timeout=timeout)
         if self.isAlive() or QUITTING:
-            raise TimedOut('Timed out: %s' % self.name)
+            raise TimedOut('Timed out: {0!s}'.format(self.name))
 
 
 def RunTimed(timeout, func, *args, **kwargs):
@@ -961,20 +961,20 @@ class DebugFileWrapper(object):
         if name in ('fd', 'dbg', 'write', 'flush', 'close'):
             return object.__getattribute__(self, name)
         else:
-            self.dbg.write('==(%d.%s)\n' % (self.fd.fileno(), name))
+            self.dbg.write('==({0:d}.{1!s})\n'.format(self.fd.fileno(), name))
             return object.__getattribute__(self.fd, name)
 
     def write(self, data, *args, **kwargs):
-        self.dbg.write('<=(%d.write)= %s\n' % (self.fd.fileno(),
+        self.dbg.write('<=({0:d}.write)= {1!s}\n'.format(self.fd.fileno(),
                                                HideBinary(data).rstrip()))
         return self.fd.write(data, *args, **kwargs)
 
     def flush(self, *args, **kwargs):
-        self.dbg.write('==(%d.flush)\n' % self.fd.fileno())
+        self.dbg.write('==({0:d}.flush)\n'.format(self.fd.fileno()))
         return self.fd.flush(*args, **kwargs)
 
     def close(self, *args, **kwargs):
-        self.dbg.write('==(%d.close)\n' % self.fd.fileno())
+        self.dbg.write('==({0:d}.close)\n'.format(self.fd.fileno()))
         return self.fd.close(*args, **kwargs)
 
 
@@ -997,6 +997,6 @@ if __name__ == "__main__":
     import doctest
     import sys
     result = doctest.testmod()
-    print '%s' % (result, )
+    print '{0!s}'.format(result )
     if result.failed:
         sys.exit(1)

--- a/mailpile/vcard.py
+++ b/mailpile/vcard.py
@@ -139,11 +139,11 @@ class VCardLine(dict):
         for k, v in self._attrs:
             k = k.upper()
             if v is None:
-                key += ';%s' % (self.Quote(k))
+                key += ';{0!s}'.format((self.Quote(k)))
             else:
-                key += ';%s=%s' % (self.Quote(k), self.Quote(unicode(v)))
+                key += ';{0!s}={1!s}'.format(self.Quote(k), self.Quote(unicode(v)))
 
-        wrapped, line = '', '%s:%s' % (key, self.Quote(self._value))
+        wrapped, line = '', '{0!s}:{1!s}'.format(key, self.Quote(self._value))
         llen = 0
         for char in line:
             char = char.encode('utf-8')
@@ -336,7 +336,7 @@ class SimpleVCard(object):
             self.load(data=kwargs['data'])
         if 'client' in kwargs and kwargs['client']:
             self.add(VCardLine(name='CLIENTPIDMAP',
-                               value='%s;%s' % (self.MAX_SRC_PID,
+                               value='{0!s};{1!s}'.format(self.MAX_SRC_PID,
                                                 kwargs['client'])))
             self._default_src_pid = self.MAX_SRC_PID
         self.add(*lines)
@@ -368,8 +368,7 @@ class SimpleVCard(object):
                 vcl = self._lines[index]
                 if vcl and vcl.line_id in line_ids:
                     if self._lines[index].name in self.UNREMOVABLE:
-                        raise ValueError('Cannot remove %s from VCard'
-                                         % self._lines[index].name)
+                        raise ValueError('Cannot remove {0!s} from VCard'.format(self._lines[index].name))
                     self._lines[index] = None
                     removed += 1
         return removed
@@ -422,10 +421,10 @@ class SimpleVCard(object):
                 count = len([l for l in self._lines
                              if l and l.name == vcl.name])
                 if not cardinality:
-                    raise ValueError('Not allowed on card: %s' % vcl.name)
+                    raise ValueError('Not allowed on card: {0!s}'.format(vcl.name))
                 if cardinality in ('1', '*1'):
                     if count:
-                        raise ValueError('Already on card: %s' % vcl.name)
+                        raise ValueError('Already on card: {0!s}'.format(vcl.name))
 
                 # Special case to avoid duplicate CLIENTPIDMAP lines
                 if vcl.name == 'clientpidmap':
@@ -439,7 +438,7 @@ class SimpleVCard(object):
                 if (src_pid is not None and
                         vcl.name not in self.UNREMOVABLE and
                         'pid' not in vcl):
-                    vcl.set_attr('pid', '%s.%s' % (src_pid, version))
+                    vcl.set_attr('pid', '{0!s}.{1!s}'.format(src_pid, version))
                 self._lines.append(vcl)
                 vcl.line_id = len(self._lines)
 
@@ -463,7 +462,7 @@ class SimpleVCard(object):
         if (src_pid is not None and
                 vcl.name not in self.UNREMOVABLE and
                 'pid' not in vcl):
-            vcl.set_attr('pid', '%s.%s' % (src_pid, version))
+            vcl.set_attr('pid', '{0!s}.{1!s}'.format(src_pid, version))
 
         with self._lock:
             vcl.line_id = ln
@@ -528,11 +527,11 @@ class SimpleVCard(object):
                     raise ValueError("Client PID map is too big")
 
                 self.add(VCardLine(name='clientpidmap',
-                                   value='%s;%s' % (src_pid, src_id)))
+                                   value='{0!s};{1!s}'.format(src_pid, src_id)))
                 pidmap = cpm[src_pid] = cpm[src_id] = {'lines': []}
                 is_new = True
             else:
-                raise KeyError('No such CLIENTPIDMAP: %s' % src_id)
+                raise KeyError('No such CLIENTPIDMAP: {0!s}'.format(src_id))
 
             version = 0
             for ver, ol in pidmap['lines'][:]:
@@ -653,10 +652,10 @@ class SimpleVCard(object):
                 for ol in old:
                     pids = [pid for pid in ol.get('pid', '').split(',')
                             if pid and int(pid.split('.')[0]) != src_pid]
-                    pids.append('%s.%s' % (src_pid, version))
+                    pids.append('{0!s}.{1!s}'.format(src_pid, version))
                     ol.set_attr('pid', ','.join(sorted(pids)))
                 if not old:
-                    vcl.set_attr('pid', '%s.%s' % (src_pid, version))
+                    vcl.set_attr('pid', '{0!s}.{1!s}'.format(src_pid, version))
                     self.add(vcl)
                     changes += 1
 
@@ -800,7 +799,7 @@ class MailpileVCard(SimpleVCard):
 
         # Add the priority CLIENTPIDMAP line, for user settings
         self.add(VCardLine(name='CLIENTPIDMAP',
-                           value='%s;%s' % (self.MAX_SRC_PID + 1,
+                           value='{0!s};{1!s}'.format(self.MAX_SRC_PID + 1,
                                             self.PRIORITY_CLIENT)))
         self._priority_client = self.MAX_SRC_PID + 1
 
@@ -884,7 +883,7 @@ class MailpileVCard(SimpleVCard):
         if (not len(lines) >= 2 or
                 not lines.pop(0).upper() == 'BEGIN:VCARD' or
                 not lines.pop(-1).upper() == 'END:VCARD'):
-            raise ValueError('Not a valid VCard: %s' % '\n'.join(lines))
+            raise ValueError('Not a valid VCard: {0!s}'.format('\n'.join(lines)))
 
         with self._lock:
             for line in lines:
@@ -952,7 +951,7 @@ class MailpileVCard(SimpleVCard):
                 self.add(history_vcl)
             now = now if (now is not None) else time.time()
             entries, history = self._history_parse_expire(history_vcl, now)
-            entries.append('%s-%s-%s' % (what[0], b36(int(when)), mid))
+            entries.append('{0!s}-{1!s}-{2!s}'.format(what[0], b36(int(when)), mid))
             history_vcl.value = ','.join(entries)
 
     def same_domain(self, address):
@@ -1275,14 +1274,12 @@ class VCardStore(dict):
                     try:
                         def ccb(key, card):
                             if session:
-                                session.ui.error('DISABLING %s, eclipses %s'
-                                                 % (path, key))
+                                session.ui.error('DISABLING {0!s}, eclipses {1!s}'.format(path, key))
                             os.rename(path, path + '.bak')
                             raise ValueError('Eclipsing')
                         self.index_vcard(c, collision_callback=ccb)
                         if session:
-                            session.ui.mark('Loaded %s from %s'
-                                            % (c.email, fn))
+                            session.ui.mark('Loaded {0!s} from {1!s}'.format(c.email, fn))
                     except ValueError:
                         pass
                 except KeyboardInterrupt:
@@ -1295,7 +1292,7 @@ class VCardStore(dict):
                         if 'vcard' in self.config.sys.debug:
                             import traceback
                             traceback.print_exc()
-                        session.ui.warning('Failed to load vcard %s' % fn)
+                        session.ui.warning('Failed to load vcard {0!s}'.format(fn))
             self.loaded = True
         except (OSError, IOError):
             pass
@@ -1489,7 +1486,7 @@ class VCardPluginClass:
         if not self.config.guid:
             if not guid:
                 global GUID_COUNTER
-                guid = 'urn:uuid:mp-%s-%x-%x' % (self.SHORT_NAME, time.time(),
+                guid = 'urn:uuid:mp-{0!s}-{1:x}-{2:x}'.format(self.SHORT_NAME, time.time(),
                                                  GUID_COUNTER)
                 GUID_COUNTER += 1
             self.config.guid = guid
@@ -1619,6 +1616,6 @@ if __name__ == "__main__":
     cfg = mailpile.config.ConfigManager(rules=mailpile.defaults.CONFIG_RULES)
     results = doctest.testmod(optionflags=doctest.ELLIPSIS,
                               extraglobs={'cfg': cfg})
-    print '%s' % (results, )
+    print '{0!s}'.format(results )
     if results.failed:
         sys.exit(1)

--- a/mailpile/vfs.py
+++ b/mailpile/vfs.py
@@ -239,7 +239,7 @@ class MailpileVFS(MailpileVfsBase):
         for prio, handler in VFS_HANDLERS:
             if handler.Handles(path):
                 return handler
-        raise IOError('Invalid path: %s' % path)
+        raise IOError('Invalid path: {0!s}'.format(path))
 
     def glob_(self, path, *args, **kwargs):
         return self._delegate(path).glob_(path, *args, **kwargs)
@@ -357,8 +357,8 @@ class MailpileVfsRoot(MailpileVfsBase):
                 for profile in os.listdir(tbird_home):
                     profpath = os.path.join(tbird_home, profile)
                     if os.path.exists(os.path.join(profpath, 'Mail')):
-                        eid = 'tbird-%s' % profile
-                        name = 'Thunderbird %s' % profile.split('.', 1)[-1]
+                        eid = 'tbird-{0!s}'.format(profile)
+                        name = 'Thunderbird {0!s}'.format(profile.split('.', 1)[-1])
                         self.entries[eid] = (FilePath(profpath), name)
 
     def _entries(self):
@@ -366,7 +366,7 @@ class MailpileVfsRoot(MailpileVfsBase):
         for msid, msobj in self.config.mail_sources.iteritems():
             if not msobj.my_config.enabled:
                 continue
-            e['msrc.%s' % msid] = (FilePath('/src:%s' % msid), msobj.name,
+            e['msrc.{0!s}'.format(msid)] = (FilePath('/src:{0!s}'.format(msid)), msobj.name,
                                    'MailSource')
         return e
 

--- a/mailpile/workers.py
+++ b/mailpile/workers.py
@@ -39,7 +39,7 @@ class Cron(threading.Thread):
         self.lock = WorkerLock()
 
     def __str__(self):
-        return '%s: %s (%ds)' % (threading.Thread.__str__(self),
+        return '{0!s}: {1!s} ({2:d}s)'.format(threading.Thread.__str__(self),
                                  self.running, time.time() - self.last_run)
 
     def add_task(self, name, interval, task):
@@ -118,7 +118,7 @@ class Cron(threading.Thread):
                                            ) % (name, self.name, e))
                 finally:
                     self.last_run = time.time()
-                    self.running = 'Finished %s' % self.running
+                    self.running = 'Finished {0!s}'.format(self.running)
 
             # Some tasks take longer than others, so use the time before
             # executing tasks as reference for the delay
@@ -175,8 +175,7 @@ class Worker(threading.Thread):
         self.wait_until = None
 
     def __str__(self):
-        return ('%s: %s (%ds, jobs=%s, jobs_after=%s)'
-                % (threading.Thread.__str__(self),
+        return ('{0!s}: {1!s} ({2:d}s, jobs={3!s}, jobs_after={4!s})'.format(threading.Thread.__str__(self),
                    self.running,
                    time.time() - self.last_run,
                    len(self.JOBS), len(self.JOBS_LATER)))
@@ -269,12 +268,12 @@ class Worker(threading.Thread):
                 self.last_run = time.time()
                 self.running = name
                 if session:
-                    session.ui.mark('Starting: %s' % name)
+                    session.ui.mark('Starting: {0!s}'.format(name))
                     session.report_task_completed(name, task())
                 else:
                     task()
             except (JobPostponingException), e:
-                session.ui.debug('Postponing: %s' % name)
+                session.ui.debug('Postponing: {0!s}'.format(name))
                 self.add_task(session, name, task,
                               after=time.time() + e.seconds)
             except (IOError, OSError), e:
@@ -284,7 +283,7 @@ class Worker(threading.Thread):
                 self._failed(session, name, task, e)
             finally:
                 self.last_run = time.time()
-                self.running = 'Finished %s' % self.running
+                self.running = 'Finished {0!s}'.format(self.running)
 
     def pause(self, session, first=False):
         with self.LOCK:
@@ -308,7 +307,7 @@ class Worker(threading.Thread):
     def die_soon(self, session=None):
         def die():
             self.ALIVE = False
-        self.add_task(session, '%s shutdown' % self.name, die)
+        self.add_task(session, '{0!s} shutdown'.format(self.name), die)
 
     def quit(self, session=None, join=True):
         self.die_soon(session=session)
@@ -378,6 +377,6 @@ if __name__ == "__main__":
     import sys
     result = doctest.testmod(optionflags=doctest.ELLIPSIS,
                              extraglobs={'junk': {}})
-    print '%s' % (result, )
+    print '{0!s}'.format(result )
     if result.failed:
         sys.exit(1)

--- a/mailpile/www/jinjaextensions.py
+++ b/mailpile/www/jinjaextensions.py
@@ -34,7 +34,7 @@ while dirname and tail and os.path.exists(dirname):
     if os.path.exists(fetch_head):
         try:
             md5 = md5_hex(open(fetch_head, 'r').read())
-            VERSION_IDENTIFIER = '%s-%s' % (APPVER, md5[:8])
+            VERSION_IDENTIFIER = '{0!s}-{1!s}'.format(APPVER, md5[:8])
             break
         except (OSError, IOError):
             break
@@ -173,12 +173,11 @@ class MailpileCommand(Extension):
 
     def _command(self, command, *args, **kwargs):
         rv = Action(self.env.session, command, args, data=kwargs).as_dict()
-        self._debug('mailpile(%s, %s, %s) -> %s'
-                    % (command, args, kwargs, rv))
+        self._debug('mailpile({0!s}, {1!s}, {2!s}) -> {3!s}'.format(command, args, kwargs, rv))
         return rv
 
     def _command_render(self, how, command, *args, **kwargs):
-        self._debug('mailpile_render(%s, %s, ...)' % (how, command))
+        self._debug('mailpile_render({0!s}, {1!s}, ...)'.format(how, command))
         old_ui, config = self.env.session.ui, self.env.session.config
         try:
             ui = self.env.session.ui = HttpUserInteraction(None, config,
@@ -194,12 +193,12 @@ class MailpileCommand(Extension):
             self.env.session.ui = old_ui
 
     def _use_data_view(self, view_name, result):
-        self._debug('use_data_view(%s, ...)' % (view_name))
+        self._debug('use_data_view({0!s}, ...)'.format((view_name)))
         dv = UrlMap(self.env.session).map(None, 'GET', view_name, {}, {})[-1]
         return dv.view(result)
 
     def _get_ui_elements(self, ui_type, state, context=None):
-        self._debug('get_ui_element(%s, %s, ...)' % (ui_type, state))
+        self._debug('get_ui_element({0!s}, {1!s}, ...)'.format(ui_type, state))
         ctx = context or state.get('context_url', '')
         return copy.deepcopy(PluginManager().get_ui_elements(ui_type, ctx))
 
@@ -233,17 +232,15 @@ class MailpileCommand(Extension):
             return url + frag
 
     def _ui_elements_setup(self, classfmt, elements):
-        self._debug('ui_elements_setup(%s, %s)' % (classfmt, elements))
+        self._debug('ui_elements_setup({0!s}, {1!s})'.format(classfmt, elements))
         setups = []
         for elem in elements:
             if elem.get('javascript_setup'):
-                setups.append('$("%s").each(function(){%s(this);});'
-                              % (classfmt % elem, elem['javascript_setup']))
+                setups.append('$("{0!s}").each(function(){{{1!s}(this);}});'.format(classfmt % elem, elem['javascript_setup']))
             if elem.get('javascript_events'):
                 for event, call in elem.get('javascript_events').iteritems():
-                    setups.append('$("%s").bind("%s", %s);' %
-                        (classfmt % elem, event, call))
-        return Markup("function(){%s}" % ''.join(setups))
+                    setups.append('$("{0!s}").bind("{1!s}", {2!s});'.format(classfmt % elem, event, call))
+        return Markup("function(){{{0!s}}}".format(''.join(setups)))
 
     def _regex_replace(self, s, find, replace):
         """A non-optimal implementation of a regex filter"""
@@ -262,8 +259,7 @@ class MailpileCommand(Extension):
         if "photo" in contact:
             photo = contact['photo']
         else:
-            photo = ('%s/static/img/avatar-default.png'
-                     % self.env.session.config.sys.http_path)
+            photo = ('{0!s}/static/img/avatar-default.png'.format(self.env.session.config.sys.http_path))
         return photo
 
     def _navigation_on(self, search_tag_ids, on_tid):
@@ -275,7 +271,7 @@ class MailpileCommand(Extension):
                     return ""
 
     def _has_label_tags(self, tags, tag_tids):
-        self._debug('has_label_tags(..., %s, ...)' % (tag_tids,))
+        self._debug('has_label_tags(..., {0!s}, ...)'.format(tag_tids))
         count = 0
         for tid in tag_tids:
             if tags[tid]["label"] and not tags[tid]["searched"]:
@@ -538,15 +534,14 @@ class MailpileCommand(Extension):
                          person['address'])
 
         if 'contact' in person['flags']:
-            url = ("%s/contacts/view/%s/"
-                   % (self.env.session.config.sys.http_path,
+            url = ("{0!s}/contacts/view/{1!s}/".format(self.env.session.config.sys.http_path,
                       person['address']))
         else:
-            url = "%s/#add-contact" % self.env.session.config.sys.http_path
+            url = "{0!s}/#add-contact".format(self.env.session.config.sys.http_path)
         return url
 
     def _contact_name(self, person):
-        self._debug('contact_name(%s)' % (person,))
+        self._debug('contact_name({0!s})'.format(person))
         name = person['fn']
         if (not name or '@' in name) and person.get('email'):
             vcard = self.env.session.config.vcards.get_vcard(person['email'])

--- a/scripts/aes-record-test.py
+++ b/scripts/aes-record-test.py
@@ -30,12 +30,12 @@ class EncryptedRecordStore(object):
         self.calculate_constants()
 
         self.iv_seed = getrandbits(48)
-        self.iv_seed_random = '%x' % getrandbits(64)
+        self.iv_seed_random = '{0:x}'.format(getrandbits(64))
         self.aes_key = key_hash[:16]
         self.header_data = {
             'record_size': self.RECORD_SIZE,
             'filename': fn,
-            'ivs': '%12.12x' % self.iv_seed
+            'ivs': '{0:12.12x}'.format(self.iv_seed)
         }
 
         try:
@@ -92,7 +92,7 @@ class EncryptedRecordStore(object):
             return False
 
     def write_header(self):
-        self.header_data['ivs'] = '%12.12x' % self.iv_seed
+        self.header_data['ivs'] = '{0:12.12x}'.format(self.iv_seed)
         header = self.HEADER % self.header_data
         self.fd.seek(0)
         self.fd.write(header)
@@ -156,12 +156,11 @@ class EncryptedRecordStore(object):
 for size in (16, 50, 100, 200, 400, 800, 1600):
     er = EncryptedRecordStore('/tmp/tmp.aes', 'this is my secret key',
                               max_bytes=size, overwrite=True)
-    print('Testing max_size=%d, real max=%d, lines=%d'
-          % (size, er.MAX_DATA_SIZE, er.RECORD_LINES))
+    print('Testing max_size={0:d}, real max={1:d}, lines={2:d}'.format(size, er.MAX_DATA_SIZE, er.RECORD_LINES))
     for l in range(0, 20):
-        er.save_record(l, 'bjarni %s' % l)
+        er.save_record(l, 'bjarni {0!s}'.format(l))
     for l in range(0, 20):
-        assert(er.load_record(l) == 'bjarni %s' % l)
+        assert(er.load_record(l) == 'bjarni {0!s}'.format(l))
 
 er = EncryptedRecordStore('test.aes', 'this is my secret key', 740)
 t0 = time.time()
@@ -172,13 +171,11 @@ for l in range(0, count):
                              'a fair bit longer, so it makes a good test '
                              'to say about this and that and the other')
 done = time.time()
-print ('100k record writes in %.2f (%.8f s/op)'
-       % (done - t0, (done - t0) / count))
+print ('100k record writes in {0:.2f} ({1:.8f} s/op)'.format(done - t0, (done - t0) / count))
 
 t0 = time.time()
 for l in range(0, count):
     er.load_record(l % 1024)
 done = time.time()
-print ('100k record reads in %.2f (%.8f s/op)'
-       % (done - t0, (done - t0) / count))
+print ('100k record reads in {0:.2f} ({1:.8f} s/op)'.format(done - t0, (done - t0) / count))
 er.close()

--- a/scripts/colorprints.py
+++ b/scripts/colorprints.py
@@ -106,18 +106,18 @@ def colorprint(fingerprint, md5shift=True, mixer=[4, 8, 4]):
         r3 = (m1*_r(rgb[0]) + m2*_r(rgb[3]) + m3*_r(rgb[6])) // 16
         g3 = (m1*_g(rgb[1]) + m2*_g(rgb[4]) + m3*_g(rgb[7])) // 16
         b3 = (m1*_b(rgb[2]) + m2*_b(rgb[5]) + m3*_b(rgb[8])) // 16
-        r1 = '%2.2x' % _r(rgb[3])
-        g1 = '%2.2x' % _g(rgb[4])
-        b1 = '%2.2x' % _b(rgb[5])
+        r1 = '{0:2.2x}'.format(_r(rgb[3]))
+        g1 = '{0:2.2x}'.format(_g(rgb[4]))
+        b1 = '{0:2.2x}'.format(_b(rgb[5]))
 
-        fr, fg, fb = ['%2.2x' % ((4*c)/5 +0x00) for c in (r3, g3, b3)]
-        br, bg, bb = ['%2.2x' % ((4*c)/5 +0x33) for c in (r3, g3, b3)]
-        rr, gg, bb = ['%2.2x' % c for c in (r3, g3, b3)]
+        fr, fg, fb = ['{0:2.2x}'.format(((4*c)/5 +0x00)) for c in (r3, g3, b3)]
+        br, bg, bb = ['{0:2.2x}'.format(((4*c)/5 +0x33)) for c in (r3, g3, b3)]
+        rr, gg, bb = ['{0:2.2x}'.format(c) for c in (r3, g3, b3)]
 
-        pairs.append(['#%s%s%s' % (rr, gg, bb),  # Mixed
-                      '#%s%s%s' % (r1, g1, b1),  # RGB: Plain
-                      '#%s%s%s' % (fr, fg, fb),  # RGB: Foreground
-                      '#%s%s%s' % (br, bg, bb),  # RGB: Background
+        pairs.append(['#{0!s}{1!s}{2!s}'.format(rr, gg, bb),  # Mixed
+                      '#{0!s}{1!s}{2!s}'.format(r1, g1, b1),  # RGB: Plain
+                      '#{0!s}{1!s}{2!s}'.format(fr, fg, fb),  # RGB: Foreground
+                      '#{0!s}{1!s}{2!s}'.format(br, bg, bb),  # RGB: Background
                       _int(fingerprint[i*2:i*2+2]),
                       fingerprint[i*2:i*2+2]])
 
@@ -184,9 +184,9 @@ def colorprint2(fingerprint, md5shift=True):
         sbtG = (val & 0x30) << 2
         sbtB = (val & 0x0b) << 4
 
-        pairs.append(['#%2.2x%2.2x%2.2x' % (sbtR, sbtG, sbtB),  # sixbytwo
-                      '#%2.2x%2.2x%2.2x' % (r1, g1, b1),        # RGB
-                      '#%2.2x%2.2x%2.2x' % (rm, gm, bm),        # Mixed
+        pairs.append(['#{0:2.2x}{1:2.2x}{2:2.2x}'.format(sbtR, sbtG, sbtB),  # sixbytwo
+                      '#{0:2.2x}{1:2.2x}{2:2.2x}'.format(r1, g1, b1),        # RGB
+                      '#{0:2.2x}{1:2.2x}{2:2.2x}'.format(rm, gm, bm),        # Mixed
                       val,
                       rval & 0xe0,        # 0xc0 == 2 bits per channel
                       val & 0x18,         # These bits are orphans!
@@ -203,10 +203,10 @@ def tohtml(cprint, brk=False):
         if brk and ((i % 4) == 3):
             pairs.append('<br>')
     # Fixed width font, so all our rainbows have the same proportions.
-    return '<tt>%s</tt>\n' % ''.join(pairs)
+    return '<tt>{0!s}</tt>\n'.format(''.join(pairs))
 
 def toangel(slices, fingerprint, copy=True, size=64):
-    return ''.join(['<span class=angel title="%s">' % fingerprint,
+    return ''.join(['<span class=angel title="{0!s}">'.format(fingerprint),
                     ('<script>document.write("<img '
                      'src=\'"+getWheel(%s, %s)+"\'>");</script>'
                      ) % (size, slices, ),
@@ -302,6 +302,6 @@ for line in """\
             print '<br>'
 
 print '<hr>'
-print 'Generated: %s' % datetime.datetime.now().ctime()
+print 'Generated: {0!s}'.format(datetime.datetime.now().ctime())
 print '</body></html>'
 

--- a/scripts/create-debian-changelog.py
+++ b/scripts/create-debian-changelog.py
@@ -11,13 +11,13 @@ def getLogMessage(commitSHA):
 
 def versionFromCommitNo(commitNo):
     """Generate a version string from a numerical commit no"""
-    return "0.0.0-dev%d" % commitNo
+    return "0.0.0-dev{0:d}".format(commitNo)
 
 #Execute git rev-list $(git rev-parse HEAD) to get list of revisions
 head = check_output(["git","rev-parse","HEAD"]).strip()
 revisions = check_output(["git","rev-list",head]).strip().split("\n")
 #Revisions now contains rev identifiers, newest revisions first.
-print "Found %d revisions" % len(revisions)
+print "Found {0:d} revisions".format(len(revisions))
 revisions.reverse() #In-place reverse, to make oldest revision first
 #Map the revisions to their log msgs
 print "Mapping revisions to log messages"
@@ -32,6 +32,6 @@ firstCommitMsg = revLogMsgs[0]
 call(["dch","--create","-v",versionFromCommitNo(0),"--package","mailpile",firstCommitMsg])
 #Create the changelog entry for all other commits
 for i in range(1, len(revisions)):
-    print "Generating changelog for revision %d" % i
+    print "Generating changelog for revision {0:d}".format(i)
     commitMsg = revLogMsgs[i]
     call(["dch","-v",versionFromCommitNo(i),"--package","mailpile",commitMsg])

--- a/scripts/email-parsing-test.py
+++ b/scripts/email-parsing-test.py
@@ -23,10 +23,10 @@ from mailpile.mailutils import AddressHeaderParser as AHP
 
 
 ahp_tests = AHP(AHP.TEST_HEADER_DATA)
-print '_tokens: %s' % ahp_tests._tokens
-print '_groups: %s' % ahp_tests._groups
-print '%s' % ahp_tests
-print 'normalized: %s' % ahp_tests.normalized()
+print '_tokens: {0!s}'.format(ahp_tests._tokens)
+print '_groups: {0!s}'.format(ahp_tests._groups)
+print '{0!s}'.format(ahp_tests)
+print 'normalized: {0!s}'.format(ahp_tests.normalized())
 
 
 headers, header, inheader = {}, None, False
@@ -39,11 +39,11 @@ for line in sys.stdin:
                     try:
                         nv = AHP(val, _raise=True).normalized()
                         if '\\' in nv:
-                            print 'ESCAPED: %s: %s (was %s)' % (hdr, nv, val)
+                            print 'ESCAPED: {0!s}: {1!s} (was {2!s})'.format(hdr, nv, val)
                         else:
-                            print '%s' % (nv,)
+                            print '{0!s}'.format(nv)
                     except ValueError:
-                        print 'FAILED: %s: %s -- %s' % (hdr, val,
+                        print 'FAILED: {0!s}: {1!s} -- {2!s}'.format(hdr, val,
                             traceback.format_exc().replace('\n', '  '))
             headers, header, inheader = {}, None, False
         elif line[:1] in (' ', '\t') and header:

--- a/scripts/mailpile-test.py
+++ b/scripts/mailpile-test.py
@@ -40,7 +40,7 @@ MY_NAME = 'Mailpile Team'
 MY_KEYID = '0x7848252F'
 
 # First, we set up a pristine Mailpile
-os.system('rm -rf %s' % mailpile_home)
+os.system('rm -rf {0!s}'.format(mailpile_home))
 mp = Mailpile(workdir=mailpile_home)
 cfg = config = mp._session.config
 ui = mp._session.ui
@@ -113,7 +113,7 @@ def do_setup():
     # Copy the test Maildir...
     for mailbox in ('Maildir', 'Maildir2'):
         path = os.path.join(mailpile_home, mailbox)
-        os.system('cp -a %s/Maildir %s' % (mailpile_test, path))
+        os.system('cp -a {0!s}/Maildir {1!s}'.format(mailpile_test, path))
 
     # Add the test mailboxes
     for mailbox in ('tests.mbx', ):
@@ -146,7 +146,7 @@ def test_load_save_rescan():
 
     # Rescan AGAIN, so we can test for the presence of duplicates and
     # verify that the move-detection code actually works.
-    os.system('rm -f %s/Maildir/*/*' % mailpile_home)
+    os.system('rm -f {0!s}/Maildir/*/*'.format(mailpile_home))
     mp.add(os.path.join(mailpile_home, 'Maildir2'))
     mp.rescan('mailboxes')
 
@@ -177,7 +177,7 @@ def test_load_save_rescan():
                    [u'subject:' + IS_CHARS, 'subject:UTF'],
                    ['use_libusb', 'unsubscribe', 'vger'],
                    ):
-        say('Searching for: %s' % search)
+        say('Searching for: {0!s}'.format(search))
         results = mp.search(*search)
         assert(results.result['stats']['count'] == 1)
 
@@ -193,7 +193,7 @@ def test_message_data():
     # Load up a message and take a look at it...
     search_md = mp.search('subject:emerging').result
     result_md = search_md['data']['metadata'][search_md['thread_ids'][0]]
-    view_md = mp.view('=%s' % result_md['mid']).result
+    view_md = mp.view('={0!s}'.format(result_md['mid'])).result
 
     # That loaded?
     message_md = view_md['data']['messages'][result_md['mid']]
@@ -202,7 +202,7 @@ def test_message_data():
     # Load up another message and take a look at it...
     search_bre = mp.search(*FROM_BRE).result
     result_bre = search_bre['data']['metadata'][search_bre['thread_ids'][0]]
-    view_bre = mp.view('=%s' % result_bre['mid']).result
+    view_bre = mp.view('={0!s}'.format(result_bre['mid'])).result
 
     # Make sure message threading is working (there are message-ids and
     # references in the test data).
@@ -212,19 +212,19 @@ def test_message_data():
     metadata_bre = view_bre['data']['metadata'][view_bre['message_ids'][0]]
     message_bre = view_bre['data']['messages'][view_bre['message_ids'][0]]
     from_bre = search_bre['data']['addresses'][metadata_bre['from']['aid']]
-    say('Checking encoding: %s' % from_bre)
+    say('Checking encoding: {0!s}'.format(from_bre))
     assert('=C3' not in from_bre['fn'])
     assert('=C3' not in from_bre['address'])
     for key, val in message_bre['header_list']:
         if key.lower() not in ('from', 'to', 'cc'):
             continue
-        say('Checking encoding: %s: %s' % (key, val))
+        say('Checking encoding: {0!s}: {1!s}'.format(key, val))
         assert('utf' not in val)
 
     # This message broke our HTML engine that one time
     search_md = mp.search('from:heretic', 'subject:outcome').result
     result_md = search_md['data']['metadata'][search_md['thread_ids'][0]]
-    view_md = mp.view('=%s' % result_md['mid'])
+    view_md = mp.view('={0!s}'.format(result_md['mid']))
     assert('Outcome' in view_md.as_html())
 
 
@@ -240,8 +240,8 @@ def test_composition():
 
     # Edit the message (moves from Blank to Draft, not findable in index)
     msg_data = {
-        'to': ['%s#%s' % (MY_FROM, MY_KEYID)],
-        'bcc': ['secret@test.com#%s' % MY_KEYID],
+        'to': ['{0!s}#{1!s}'.format(MY_FROM, MY_KEYID)],
+        'bcc': ['secret@test.com#{0!s}'.format(MY_KEYID)],
         'mid': [new_mid],
         'subject': ['This the TESTMSG subject'],
         'body': ['Hello world!'],
@@ -267,16 +267,16 @@ def test_composition():
     config.routes['default'] = {"command": '/no/such/file'}
     mp.sendmail()
     events = mp.eventlog('source=mailpile.plugins.compose.Sendit',
-                         'data_mid=%s' % new_mid).result['events']
+                         'data_mid={0!s}'.format(new_mid)).result['events']
     assert(len(events) == 1)
     assert(events[0]['flags'] == 'i')
     assert(len(mp.eventlog('incomplete').result['events']) == 1)
 
     # Second attempt should succeed!
-    config.routes.default.command = '%s -i %%(rcpt)s' % mailpile_send
+    config.routes.default.command = '{0!s} -i %(rcpt)s'.format(mailpile_send)
     mp.sendmail()
     events = mp.eventlog('source=mailpile.plugins.compose.Sendit',
-                         'data_mid=%s' % new_mid).result['events']
+                         'data_mid={0!s}'.format(new_mid)).result['events']
     assert(len(events) == 1)
     assert(events[0]['flags'] == 'c')
     assert(len(mp.eventlog('incomplete').result['events']) == 0)
@@ -299,7 +299,7 @@ def test_composition():
                    ['thisisauniquestring',
                     'in:mp_sig-verified', 'in:mp_enc-none', 'in:sent'],
                    ['subject:TESTMSG']):
-        say('Searching for: %s' % search)
+        say('Searching for: {0!s}'.format(search))
         assert(mp.search(*search).result['stats']['count'] == 1)
     # This is the base64 encoding of thisisauniquestring
     assert('dGhpc2lzYXVuaXF1ZXN0cmluZ' in contents(mailpile_sent))
@@ -324,7 +324,7 @@ def test_smtp():
     config.prepare_workers(mp._session, daemons=True)
     new_mid = mp.message_compose().result['thread_ids'][0]
     msg_data = {
-        'from': ['%s#%s' % (MY_FROM, MY_KEYID)],
+        'from': ['{0!s}#{1!s}'.format(MY_FROM, MY_KEYID)],
         'mid': [new_mid],
         'subject': ['This the OTHER TESTMSG...'],
         'body': ['Hello SMTP world!']
@@ -345,7 +345,7 @@ def test_html():
     say("Testing HTML")
 
     mp.output("jhtml")
-    assert('&lt;bang&gt;' in '%s' % mp.search('in:inbox').as_html())
+    assert('&lt;bang&gt;' in '{0!s}'.format(mp.search('in:inbox').as_html()))
     mp.output("text")
 
 
@@ -374,10 +374,10 @@ if '-i' in sys.argv:
     mp.set('prefs/vcard/importers/gravatar/0/active = true')
     mp.set('prefs/vcard/importers/gpg/0/active = true')
     mp._session.ui = ui
-    print '%s' % mp.help_splash()
+    print '{0!s}'.format(mp.help_splash())
     mp.Interact()
 
 
 ##[ Cleanup ]#################################################################
 config.stop_workers()
-os.system('rm -rf %s' % mailpile_home)
+os.system('rm -rf {0!s}'.format(mailpile_home))

--- a/scripts/mbox-minimal.py
+++ b/scripts/mbox-minimal.py
@@ -50,4 +50,4 @@ with open(sys.argv[1], 'rb') as fd:
 print ('Done, found %d messages, %d msgids'
        ) % (len(messages), len([1 for mi in msgids if mi]))
 for i in range(0, 20):
-    print '%d/%d = %s' % (i * 13, messages[i], msgids[i * 13])
+    print '{0:d}/{1:d} = {2!s}'.format(i * 13, messages[i], msgids[i * 13])

--- a/scripts/mk-credits.py
+++ b/scripts/mk-credits.py
@@ -34,7 +34,7 @@ authors = [(c, n, e) for e, (n, c) in authors.iteritems()]
 
 # Get translators from .po files
 for lang in os.listdir('shared-data/locale'):
-    po = 'shared-data/locale/%s/LC_MESSAGES/mailpile.po' % lang
+    po = 'shared-data/locale/{0!s}/LC_MESSAGES/mailpile.po'.format(lang)
     tr = translators[lang] = ['', []]
     try:
         with open(po, 'r') as fd:
@@ -54,7 +54,7 @@ code = 'shared-data/default-theme/html/page/release-notes/credits-code.html'
 i18n = 'shared-data/default-theme/html/page/release-notes/credits-i18n.html'
 with open(code, 'w') as fd:
     authors.sort(key=lambda a: a[1])
-    fd.write('\n'.join('<li class="commits-%s">%s</li>' % (a[0], a[1])
+    fd.write('\n'.join('<li class="commits-{0!s}">{1!s}</li>'.format(a[0], a[1])
                        for a in authors))
 
 with open(i18n, 'w') as fd:
@@ -62,10 +62,10 @@ with open(i18n, 'w') as fd:
     for lang in sorted(translators.keys()):
         language, tlist = translators[lang]
         if language:
-            fd.write('<li class="language">%s</li>\n' % language)
-            fd.write(''.join('<li>%s</li>\n' % re.sub(email, '', n)
+            fd.write('<li class="language">{0!s}</li>\n'.format(language))
+            fd.write(''.join('<li>{0!s}</li>\n'.format(re.sub(email, '', n))
                              for n in sorted(tlist)))
         elif translators[lang][1]:
-            print 'wtf: %s' % translators[lang]
+            print 'wtf: {0!s}'.format(translators[lang])
 
-os.system('ls -l %s %s' % (code, i18n))
+os.system('ls -l {0!s} {1!s}'.format(code, i18n))

--- a/scripts/unsent-mail-finder.py
+++ b/scripts/unsent-mail-finder.py
@@ -26,8 +26,8 @@ for line in sys.stdin.readlines():
         elif msg.startswith('Connecting'):
             sendits[eid][5]['OK'] = True
   except ValueError:
-    print 'Unparsable: %s' % line
+    print 'Unparsable: {0!s}'.format(line)
 
 for eid, data in sendits.iteritems():
     if 'OK' not in data[5]:
-        print 'On %s, failed to send %s' % (data[0], data[5]['mid'])
+        print 'On {0!s}, failed to send {1!s}'.format(data[0], data[5]['mid'])

--- a/setup.py
+++ b/setup.py
@@ -60,11 +60,11 @@ try:
 except (OSError, IOError):
     BRANCH = None
 if BRANCH:
-    BRANCHVER = '.%s%s' % (BRANCH, str(datetime.date.today()).replace('-', ''))
+    BRANCHVER = '.{0!s}{1!s}'.format(BRANCH, str(datetime.date.today()).replace('-', ''))
 else:
     BRANCHVER = ''
 
-APPVER = '%s%s' % (next(
+APPVER = '{0!s}{1!s}'.format(next(
     line.strip() for line in open('mailpile/defaults.py', 'r')
     if re.match(r'^APPVER\s*=', line)
 ).split('"')[1], BRANCHVER)

--- a/shared-data/contrib/datadig/datadig.py
+++ b/shared-data/contrib/datadig/datadig.py
@@ -99,7 +99,7 @@ class dataDigCommand(Command):
         without_mid |= truthy(self.data.get('no-mid', [''])[0])
         tracking_id = self.data.get('track-id', [tracking_id])[0]
         columns.extend(self.data.get('term', []))
-        msgs.extend(['=%s' % mid.replace('=', '')
+        msgs.extend(['={0!s}'.format(mid.replace('=', ''))
                      for mid in self.data.get('mid', [])])
 
         # Add a header to the CSV if requested
@@ -126,7 +126,7 @@ class dataDigCommand(Command):
                 self._update_event_state(self.event.RUNNING, log=True)
             else:
                 session.ui.mark(_('Digging into =%s') % e.msg_mid())
-            row = [] if without_mid else ['%s' % e.msg_mid()]
+            row = [] if without_mid else ['{0!s}'.format(e.msg_mid())]
             for cellspec in columns:
                 row.extend(self._cell(idx, e, cellspec))
             results.append(row)

--- a/shared-data/contrib/demos/demos.py
+++ b/shared-data/contrib/demos/demos.py
@@ -121,7 +121,7 @@ class md5sumWordyView(md5sumCommand):
     """Represent MD5 sums in a more wordy way."""
     @classmethod
     def view(cls, result):
-        return 'MD5:%s' % result
+        return 'MD5:{0!s}'.format(result)
 
 
 def on_plugin_start(config):

--- a/shared-data/contrib/experiments/experiments.py
+++ b/shared-data/contrib/experiments/experiments.py
@@ -101,7 +101,7 @@ class EmailCryptoTxf(EmailTransform):
                 part = _AddCryptoState(MIMEText(visible.as_string(),
                                                 'rfc822-headers'))
                 part.set_param('protected-headers',
-                               'v1,%s' % msg['Message-ID'])
+                               'v1,{0!s}'.format(msg['Message-ID']))
                 part['Content-Disposition'] = 'inline'
                 del part['MIME-Version']
                 msg.attach(part)
@@ -111,7 +111,7 @@ class EmailCryptoTxf(EmailTransform):
                 part = _AddCryptoState(MIMEText(invisible.as_string(),
                                                 'rfc822-headers'))
                 part.set_param('protected-headers',
-                               'v1,%s' % msg['Message-ID'])
+                               'v1,{0!s}'.format(msg['Message-ID']))
                 part['Content-Disposition'
                      ] = 'attachment; filename=Secure_Headers.txt'
                 del part['MIME-Version']
@@ -196,7 +196,7 @@ def paragraph_id_extractor(index, msg, ctype, textpart, **kwargs):
                     not (txt.endswith(':'))):
                 txt = re.sub(RE_CLEANPARA, '', txt)[-120:]
 #               print 'PARA: %s' % txt
-                kws.add('%s:p' % md5_hex(txt))
+                kws.add('{0!s}:p'.format(md5_hex(txt)))
             para.update({'text': '', 'qlevel': 0})
 
         for line in textpart.splitlines():

--- a/shared-data/contrib/gui/gui-o-matic.py
+++ b/shared-data/contrib/gui/gui-o-matic.py
@@ -37,7 +37,7 @@ class Indicator(object):
             uo = urllib.URLopener()
             for cookie, value in self.config.get('http_cookies', {}
                                                  ).get(base_url, []):
-                uo.addheader('Cookie', '%s=%s' % (cookie, value))
+                uo.addheader('Cookie', '{0!s}={1!s}'.format(cookie, value))
 
             if op == 'post_url':
                 (fn, hdrs) = uo.retrieve(url, data=args)
@@ -65,7 +65,7 @@ class Indicator(object):
             self._add_menu_item(**item_info)
 
     def _set_status(self, status):
-        print 'STATUS: %s' % status
+        print 'STATUS: {0!s}'.format(status)
 
     def set_status_startup(self):
         self._set_status('startup')
@@ -110,7 +110,7 @@ class Indicator(object):
         pass
 
     def notify_user(self, message='Hello'):
-        print 'NOTIFY: %s' % message
+        print 'NOTIFY: {0!s}'.format(message)
 
 
 ##[ An indicator for Ubuntu's Unity ]##########################################
@@ -281,7 +281,7 @@ def UnityIndicator():
                 notification.set_urgency(pynotify.URGENCY_NORMAL)
                 notification.show()
             else:
-                print 'FIXME: Notify: %s' % message
+                print 'FIXME: Notify: {0!s}'.format(message)
 
         _STATUS_MODES = {
             'startup': appindicator.STATUS_ACTIVE,
@@ -351,7 +351,7 @@ def MacOSXIndicator():
                     if i in self.indicator.callbacks:
                         self.indicator.callbacks[i]()
                     return
-            print 'activated an unknown item: %s' % notification
+            print 'activated an unknown item: {0!s}'.format(notification)
 
     class MailpileIndicator(Indicator):
 
@@ -439,7 +439,7 @@ class StdinWatcher(threading.Thread):
         if hasattr(self.gui, command):
             getattr(self.gui, command)(**kwargs)
         else:
-            print 'Unknown method: %s' % command
+            print 'Unknown method: {0!s}'.format(command)
 
     def run(self):
         try:

--- a/shared-data/contrib/gui/gui.py
+++ b/shared-data/contrib/gui/gui.py
@@ -18,7 +18,7 @@ __GUI__ = None
 
 
 def indicator(command, **kwargs):
-    __GUI__.stdin.write('%s %s\n' % (command, json.dumps(kwargs)))
+    __GUI__.stdin.write('{0!s} {1!s}\n'.format(command, json.dumps(kwargs)))
 
 
 def startup(config):
@@ -46,7 +46,7 @@ def _real_startup(config):
                                         session_id=session_id)
         cookie = config.http_worker.httpd.session_cookie
         sspec = config.http_worker.httpd.sspec
-        base_url = 'http://%s:%s%s' % sspec
+        base_url = 'http://{0!s}:{1!s}{2!s}'.format(*sspec)
 
         script_dir = os.path.dirname(os.path.realpath(__file__))
         script = os.path.join(script_dir, 'gui-o-matic.py')

--- a/shared-data/contrib/i18nhelper/i18nhelper.py
+++ b/shared-data/contrib/i18nhelper/i18nhelper.py
@@ -14,7 +14,7 @@ class I18NRecent(Command):
     class CommandResult(Command.CommandResult):
         def as_text(self):
             if self.result:
-                return '\n'.join(["%s: %s" % (key, value) for key, value in self.result.iteritems()])
+                return '\n'.join(["{0!s}: {1!s}".format(key, value) for key, value in self.result.iteritems()])
             else:
                 return _("Nothing recently translated")
 

--- a/shared-data/multipile/mailpile-admin.py
+++ b/shared-data/multipile/mailpile-admin.py
@@ -248,7 +248,7 @@ def app_arguments():
 
 
 def usage(ap, reason, code=3):
-    print 'error: %s' % reason
+    print 'error: {0!s}'.format(reason)
     ap.print_usage()
     sys.exit(code)
 
@@ -264,7 +264,7 @@ def parse_config(app_args,
             config.read([conf_file])
             app_args.set_defaults(**dict(config.items(section)))
         elif conf_parsed and conf_parsed.config:
-            usage(app_args, 'Config file not found: %s' % conf_file)
+            usage(app_args, 'Config file not found: {0!s}'.format(conf_file))
 
 
 def parse_arguments_and_config(app_args,
@@ -308,7 +308,7 @@ def _parse_netstat():
 def _get_random_port():
     ns = _parse_netstat()
     for tries in range(0, 100):
-       port = '%s' % random.randint(34110, 64110)
+       port = '{0!s}'.format(random.randint(34110, 64110))
        cport = ':' + port
        for lhp, rhp, pid, proc in ns:
            if lhp.endswith(cport):
@@ -401,7 +401,7 @@ def get_user_settings(args, user=None, mailpiles=None):
     if mailpiles and not port:
         ports = [int(m[2]) for m in mailpiles.values() if m[0] == user]
         if ports:
-            port = '%s' % min(ports)
+            port = '{0!s}'.format(min(ports))
     if not port:
         port = _get_random_port()
 
@@ -410,7 +410,7 @@ def get_user_settings(args, user=None, mailpiles=None):
         'mailpile': settings['mailpile'],
         'host': '127.0.0.1',
         'port': port,
-        'path': ('%s/%s/' % (args.webroot, user)).replace('//', '/'),
+        'path': ('{0!s}/{1!s}/'.format(args.webroot, user)).replace('//', '/'),
         'pidfile': pidfile,
         'idlequit': args.idlequit,
         'pid': os.path.exists(pidfile) and open(pidfile, 'r').read().strip()}
@@ -457,10 +457,10 @@ def parse_htaccess(args, os_settings, mailpiles=None):
                 m = re.match(parse, line)
                 if m:
                     host, port = m.group(2), m.group(3)
-                    mailpiles['%s:%s' % (host, port)] = [
+                    mailpiles['{0!s}:{1!s}'.format(host, port)] = [
                         m.group(1), host, port, True, None, None]
     except (OSError, IOError, KeyError), err:
-        print 'WARNING: %s' % err
+        print 'WARNING: {0!s}'.format(err)
     return mailpiles
 
 
@@ -500,10 +500,10 @@ def parse_rewritemap(args, os_settings, mailpiles=None):
                     user = m.group('user')
                     host = m.group('host')
                     port = m.group('port')
-                    mailpiles['%s:%s' % (host, port)] = [
+                    mailpiles['{0!s}:{1!s}'.format(host, port)] = [
                         user, host, port, True, None, None]
     except (OSError, IOError, KeyError), err:
-        print 'WARNING: %s' % err
+        print 'WARNING: {0!s}'.format(err)
     return mailpiles
 
 
@@ -556,10 +556,10 @@ def save_cgi(os_settings):
 def run_script(args, settings, script):
     for line in script:
         line = line % _escaped(settings)
-        print '==> %s' % line
+        print '==> {0!s}'.format(line)
         rv = os.system(line)
         if 0 != rv:
-            print '==[ FAILED! Exit code: %s ]==' % rv
+            print '==[ FAILED! Exit code: {0!s} ]=='.format(rv)
             return
     print '===[ SUCCESS! ]==='
 
@@ -585,10 +585,10 @@ def list_mailpiles(args):
         user_counts[user] = user_counts.get(user, 0) + 1
         status = []
         if in_usermap:
-            url = 'http://%s%s/%s/' % (socket.gethostname(),
+            url = 'http://{0!s}{1!s}/{2!s}/'.format(socket.gethostname(),
                                       os_settings['webroot'], user)
         else:
-            url = 'http://%s:%s/' % (host, port)
+            url = 'http://{0!s}:{1!s}/'.format(host, port)
         print fmt % (
             user, pid or '', rss or '',
             'apache' if in_usermap else 'direct', port, url)
@@ -628,10 +628,10 @@ def run_as_user(user, password, command):
 
 def run_user_command_or_script(args, user_settings, command_args, script):
     if args.user:
-        command = '"%s" %s' % (
+        command = '"{0!s}" {1!s}'.format(
             _escape(os.path.realpath(sys.argv[0])), command_args)
         if args.password:
-            print '%s%s' % run_as_user(args.user, args.password, command)
+            print '{0!s}{1!s}'.format(*run_as_user(args.user, args.password, command))
             return
         script = ['sudo -u "%(user)s" -- ' + command]
 
@@ -645,13 +645,13 @@ def start_mailpile(app_args, args):
     assert(re.match('^[0-9]+$', user_settings['port']) is not None)
     assert(re.match('^[a-z0-9\.]+$', user_settings['host']) is not None)
     if args.user:
-        command = '%s "%s" --start --port="%s" --host="%s"' % (
+        command = '{0!s} "{1!s}" --start --port="{2!s}" --host="{3!s}"'.format(
             _escape(os_settings['interpreter']),
             _escape(os_settings['mailpile-admin']),
             _escape(user_settings['port']),
             _escape(user_settings['host']))
         if args.password:
-            print '%s%s' % run_as_user(args.user, args.password, command)
+            print '{0!s}{1!s}'.format(*run_as_user(args.user, args.password, command))
             script = None
         else:
             script = ['sudo -u "%(user)s" -- ' + command]
@@ -662,7 +662,7 @@ def start_mailpile(app_args, args):
         run_script(args, user_settings, script)
 
     if args.user:
-        hostport = '%s:%s' % (user_settings['host'], user_settings['port'])
+        hostport = '{0!s}:{1!s}'.format(user_settings['host'], user_settings['port'])
         mailpiles[hostport] = (user_settings['user'],
                                user_settings['host'],
                                user_settings['port'],
@@ -742,7 +742,7 @@ def handle_cgi_post():
         settings = get_os_settings(parsed_args)
 
         # Send headers now, so output doesn't confuse Apache
-        print 'Location: %s/%s/' % (settings['webroot'], username)
+        print 'Location: {0!s}/{1!s}/'.format(settings['webroot'], username)
         print 'Expires: 0'
         print
 
@@ -753,7 +753,7 @@ def handle_cgi_post():
     except:
         parsed_args = app_args.parse_args(['--start'])
         settings = get_os_settings(parsed_args)
-        print 'Location: %s/?error=yes' % settings['webroot']
+        print 'Location: {0!s}/?error=yes'.format(settings['webroot'])
         print 'Expires: 0'
         print
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:Mailpile?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:Mailpile?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
